### PR TITLE
Fix TypeScript build errors and props for sessions

### DIFF
--- a/components/logbook/SessionItem.tsx
+++ b/components/logbook/SessionItem.tsx
@@ -5,7 +5,7 @@ export default function SessionItem({ session, onDelete, onView }: { session: an
   return (
     <View style={styles.item}>
       <Text style={styles.type}>{session.type || 'Session'}</Text>
-      <Text style={styles.date}>{new Date(session.created).toLocaleString()}</Text>
+      <Text style={styles.date}>{new Date(session.date).toLocaleString()}</Text>
       <Text style={styles.info}>Anomalies: {session.anomalies?.length ?? 0}</Text>
       <View style={styles.actions}>
         <Pressable onPress={onView} style={styles.actionButton}><Text style={styles.actionText}>View</Text></Pressable>

--- a/screens/EVPRecorder.tsx
+++ b/screens/EVPRecorder.tsx
@@ -10,6 +10,7 @@ export default function EVPRecorder() {
   const [uri, setUri] = useState<string | null>(null);
   const [markers, setMarkers] = useState<number[]>([]);
   const [anomalies, setAnomalies] = useState<any[]>([]);
+  const [audioBuffer, setAudioBuffer] = useState<number[]>([]);
 
   const start = async () => {
     await Recorder.startRecording();
@@ -26,6 +27,7 @@ export default function EVPRecorder() {
     setMarkers(Recorder.getMarkers());
     // Simulate anomaly detection (replace with real buffer later)
     const fakeBuffer = new Float32Array(2048).map(() => Math.random() * 2 - 1);
+    setAudioBuffer(Array.from(fakeBuffer));
     setAnomalies(detectAnomalies(fakeBuffer));
   };
 
@@ -70,7 +72,7 @@ export default function EVPRecorder() {
           </View>
         )}
       </View>
-      <SpectrogramPreview />
+      <SpectrogramPreview audioBuffer={audioBuffer} />
       <View style={styles.buttons}>
         {!recording ? (
           <Button title="Start Recording" onPress={start} />

--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
 import SessionStore from '../services/sessions/SessionStore';
 import SessionItem from '../components/logbook/SessionItem';
 
@@ -19,9 +19,14 @@ export default function Logbook({ navigation }: any) {
         data={sessions}
         keyExtractor={item => item.id}
         renderItem={({ item }) => (
-          <TouchableOpacity onPress={() => navigation?.navigate?.('SessionDetail', { session: item })}>
-            <SessionItem session={item} />
-          </TouchableOpacity>
+          <SessionItem
+            session={item}
+            onView={() => navigation?.navigate?.('SessionDetail', { session: item })}
+            onDelete={async () => {
+              await SessionStore.delete(item.id);
+              setSessions((prev) => prev.filter((s) => s.id !== item.id));
+            }}
+          />
         )}
         contentContainerStyle={{ padding: 16 }}
         ListEmptyComponent={<Text style={styles.empty}>No sessions yet.</Text>}

--- a/screens/SpiritBoard.tsx
+++ b/screens/SpiritBoard.tsx
@@ -15,10 +15,10 @@ export default function SpiritBoard() {
 
   // Use entropy from sensors for pointer movement
   useEffect(() => {
-    const interval = setInterval(() => {
+    const interval = setInterval(async () => {
+      const e = await getEntropy();
       setPointer((p) => {
         // Use entropy to bias movement
-        const e = getEntropy();
         let row = p.row + (e > 0.5 ? 1 : -1) * (e > 0.7 ? 1 : 0);
         let col = p.col + (e < 0.5 ? 1 : -1) * (e < 0.3 ? 1 : 0);
         row = Math.max(0, Math.min(LETTERS.length - 1, row));


### PR DESCRIPTION
## Summary
- provide SpectrogramPreview with audioBuffer state in EVP recorder
- wire up Logbook session actions and fix session date property
- fetch async entropy for SpiritBoard pointer movement

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68aea2b6a998832e90843ec4edfb263a