### PR TITLE
Standardize session timestamp property

### DIFF
--- a/components/logbook/SessionDetail.tsx
+++ b/components/logbook/SessionDetail.tsx
@@ -6,6 +6,7 @@ import { shareSessionZip } from '../../services/export/zipSession';
 
 export default function SessionDetail({ route }: any) {
   const session = route?.params?.session;
+  const created = session?.created || session?.date;
   const [playing, setPlaying] = useState(false);
   const soundRef = useRef<Audio.Sound | null>(null);
 
@@ -40,7 +41,7 @@ export default function SessionDetail({ route }: any) {
       <Text style={styles.label}>Type:</Text>
       <Text style={styles.value}>{session?.type || 'Session'}</Text>
       <Text style={styles.label}>Date:</Text>
-      <Text style={styles.value}>{new Date(session?.created).toLocaleString()}</Text>
+      <Text style={styles.value}>{new Date(created).toLocaleString()}</Text>
       <Text style={styles.label}>Anomalies:</Text>
       <Text style={styles.value}>{session?.anomalies?.length ?? 0}</Text>
       <EVoidButton

--- a/components/logbook/SessionItem.tsx
+++ b/components/logbook/SessionItem.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 // TODO: Show session summary, type, date, and quick actions
 export default function SessionItem({ session, onDelete, onView }: { session: any; onDelete: () => void; onView: () => void }) {
+  const created = session.created || session.date;
   return (
     <View style={styles.item}>
       <Text style={styles.type}>{session.type || 'Session'}</Text>
-      <Text style={styles.date}>{new Date(session.created).toLocaleString()}</Text>
+      <Text style={styles.date}>{new Date(created).toLocaleString()}</Text>
       <Text style={styles.info}>Anomalies: {session.anomalies?.length ?? 0}</Text>
       <View style={styles.actions}>
         <Pressable onPress={onView} style={styles.actionButton}><Text style={styles.actionText}>View</Text></Pressable>

--- a/screens/EVPRecorder.tsx
+++ b/screens/EVPRecorder.tsx
@@ -42,7 +42,7 @@ export default function EVPRecorder() {
       uri,
       markers,
       anomalies,
-      date: new Date().toISOString(),
+      created: new Date().toISOString(),
     };
     await SessionStore.create(session);
     Alert.alert('Session Saved', 'Your EVP session has been saved to the logbook.');

--- a/services/sessions/SessionStore.ts
+++ b/services/sessions/SessionStore.ts
@@ -34,7 +34,14 @@ async function create(session: any) {
 async function list() {
   try {
     const raw = await AsyncStorage.getItem(SESSIONS_KEY);
-    return raw ? JSON.parse(raw) : [];
+    const sessions = raw ? JSON.parse(raw) : [];
+    return sessions.map((s: any) => {
+      if (s.date && !s.created) {
+        s.created = s.date;
+        delete s.date;
+      }
+      return s;
+    });
   } catch (error) {
     console.error('Failed to list sessions:', error);
     return [];


### PR DESCRIPTION
## Summary
- use `created` field when saving EVP sessions
- normalize legacy `date` entries during SessionStore.list
- adjust logbook components to read the unified timestamp

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeb41fff00832e81ad90c6231e6a1e