### PR TITLE
Handle playback errors

### DIFF
--- a/components/logbook/SessionDetail.tsx
+++ b/components/logbook/SessionDetail.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef } from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { Text, StyleSheet, ScrollView, Alert } from 'react-native';
 import { Audio } from 'expo-av';
 import EVoidButton from '../ui/EVoidButton';
 import { shareSessionZip } from '../../services/export/zipSession';
+import { playSessionAudio } from '../../services/audio/playSessionAudio';
 
 export default function SessionDetail({ route }: any) {
   const session = route?.params?.session;
@@ -10,28 +11,9 @@ export default function SessionDetail({ route }: any) {
   const soundRef = useRef<Audio.Sound | null>(null);
 
   const handlePlay = async () => {
-    if (!session?.uri) return;
-    if (playing) {
-      if (soundRef.current) {
-        await soundRef.current.stopAsync();
-        await soundRef.current.unloadAsync();
-        soundRef.current = null;
-      }
-      setPlaying(false);
-      return;
-    }
-    try {
-      const { sound } = await Audio.Sound.createAsync({ uri: session.uri }, { shouldPlay: true });
-      soundRef.current = sound;
-      setPlaying(true);
-      sound.setOnPlaybackStatusUpdate((status) => {
-        if (!status.isLoaded || status.didJustFinish) {
-          setPlaying(false);
-          sound.unloadAsync();
-          soundRef.current = null;
-        }
-      });
-    } catch {}
+    await playSessionAudio(session, playing, setPlaying, soundRef, Audio, (title: string, message?: string) =>
+      Alert.alert(title, message)
+    );
   };
 
   return (
@@ -56,10 +38,11 @@ export default function SessionDetail({ route }: any) {
       ) : (
         <Text style={styles.value}>None</Text>
       )}
-  <EVoidButton label="Export Session" onPress={() => shareSessionZip(session)} style={{ marginTop: 24 }} />
+      <EVoidButton label="Export Session" onPress={() => shareSessionZip(session)} style={{ marginTop: 24 }} />
     </ScrollView>
   );
 }
+
 const styles = StyleSheet.create({
   detail: { flex: 1, padding: 20, backgroundColor: '#111' },
   title: { fontSize: 24, fontWeight: '800', color: '#fff', marginBottom: 16 },

--- a/services/audio/playSessionAudio.ts
+++ b/services/audio/playSessionAudio.ts
@@ -1,0 +1,53 @@
+export async function playSessionAudio(
+  session: any,
+  playing: boolean,
+  setPlaying: (val: boolean) => void,
+  soundRef: { current: any },
+  AudioModule: any,
+  alert: (title: string, message?: string) => void
+) {
+  if (!session?.uri) return;
+  if (playing) {
+    if (soundRef.current) {
+      await soundRef.current.stopAsync();
+      await soundRef.current.unloadAsync();
+      soundRef.current = null;
+    }
+    setPlaying(false);
+    return;
+  }
+
+  let sound: any = null;
+  try {
+    const result = await AudioModule.Sound.createAsync({ uri: session.uri }, { shouldPlay: true });
+    sound = result.sound;
+    soundRef.current = sound;
+    setPlaying(true);
+    sound.setOnPlaybackStatusUpdate((status: any) => {
+      if (!status.isLoaded || status.didJustFinish) {
+        setPlaying(false);
+        sound.unloadAsync();
+        soundRef.current = null;
+      }
+    });
+  } catch (err) {
+    console.error('Playback error', err);
+    if (sound) {
+      try {
+        await sound.unloadAsync();
+      } catch (e) {
+        console.error('Error unloading sound', e);
+      }
+    }
+    if (soundRef.current) {
+      try {
+        await soundRef.current.unloadAsync();
+      } catch (e) {
+        console.error('Error unloading current sound', e);
+      }
+      soundRef.current = null;
+    }
+    setPlaying(false);
+    alert('Playback Error', 'Unable to play recording.');
+  }
+}

--- a/tests/sessionDetail.test.ts
+++ b/tests/sessionDetail.test.ts
@@ -1,0 +1,29 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert';
+import { playSessionAudio } from '../services/audio/playSessionAudio';
+
+test('playSessionAudio alerts and unloads on failure', async () => {
+  const createAsyncMock = mock.fn(async () => { throw new Error('fail'); });
+  const alertMock = mock.fn();
+  const unloadMock = mock.fn(async () => {});
+  const AudioModule = { Sound: { createAsync: createAsyncMock } };
+
+  const soundRef: any = { current: { unloadAsync: unloadMock } };
+  let setPlayingVal: boolean | null = null;
+  const setPlaying = (v: boolean) => { setPlayingVal = v; };
+
+  let errorLogged = false;
+  const originalError = console.error;
+  console.error = () => { errorLogged = true; };
+
+  await playSessionAudio({ uri: 'u' }, false, setPlaying, soundRef, AudioModule, alertMock);
+
+  assert.strictEqual(createAsyncMock.mock.callCount(), 1);
+  assert.strictEqual(alertMock.mock.callCount(), 1);
+  assert.strictEqual(unloadMock.mock.callCount(), 1);
+  assert.strictEqual(soundRef.current, null);
+  assert.strictEqual(setPlayingVal, false);
+  assert.ok(errorLogged);
+
+  console.error = originalError;
+});


### PR DESCRIPTION
## Summary
- Add reusable `playSessionAudio` helper with robust error handling and user alert
- Call helper from `SessionDetail` and surface playback failures
- Test playback error path by mocking `Audio.Sound.createAsync`

## Testing
- `npm test`
- `node --test --import tsx tests/sessionDetail.test.ts`
- `node --test --import tsx tests/*.test.ts` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb424d940832e966ca6a1817ebd21