### PR TITLE
Start and stop LiveChain based on enabled flag

### DIFF
--- a/screens/LiveITC.tsx
+++ b/screens/LiveITC.tsx
@@ -51,8 +51,11 @@ function LiveITC() {
 
   // Start/stop LiveChain (mic input) when enabled changes
   useEffect(() => {
-  if (enabled) {
-    } else if (liveChainActive.current) {
+    if (enabled && !liveChainActive.current) {
+      LiveChain.startLiveChain({ onLevel: setVu, gain, fx }).then(() => {
+        liveChainActive.current = true;
+      });
+    } else if (!enabled && liveChainActive.current) {
       LiveChain.stopLiveChain();
       liveChainActive.current = false;
       setVu(0);


### PR DESCRIPTION
## Summary
- Start LiveChain when enabled and not already active
- Stop LiveChain and reset flag on disable or cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb428ce14832eba7e63a6d1693bb6