### PR TITLE
Refresh logbook with navigation focus

### DIFF
--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -1,16 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import SessionStore from '../services/sessions/SessionStore';
 import SessionItem from '../components/logbook/SessionItem';
 
 export default function Logbook({ navigation }: any) {
   const [sessions, setSessions] = useState<any[]>([]);
-  useEffect(() => {
-    (async () => {
-      const list = await SessionStore.list();
-      setSessions(list.reverse());
-    })();
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        const list = await SessionStore.list();
+        setSessions(list.reverse());
+      })();
+    }, [])
+  );
 
   return (
     <View style={styles.flex}>


### PR DESCRIPTION
## Summary
- Replace initial load `useEffect` with `useFocusEffect` so logbook reloads when screen is revisited
- Ensure sessions list refreshes immediately after saving new sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeb433e378832eb072846a385e33cb