### PR TITLE
Handle recording permission failures and expose state

### DIFF
--- a/screens/EVPRecorder.tsx
+++ b/screens/EVPRecorder.tsx
@@ -12,16 +12,21 @@ export default function EVPRecorder() {
   const [anomalies, setAnomalies] = useState<any[]>([]);
 
   const start = async () => {
-    await Recorder.startRecording();
-    setRecording(true);
-    setUri(null);
-    setMarkers([]);
-    setAnomalies([]);
+    try {
+      await Recorder.startRecording();
+      setUri(null);
+      setMarkers([]);
+      setAnomalies([]);
+    } catch (err: any) {
+      Alert.alert('Recording Failed', err.message || 'Unable to start recording.');
+    } finally {
+      setRecording(Recorder.isRecording());
+    }
   };
 
   const stop = async () => {
     const result = await Recorder.stopRecording();
-    setRecording(false);
+    setRecording(Recorder.isRecording());
     setUri(result);
     setMarkers(Recorder.getMarkers());
     // Simulate anomaly detection (replace with real buffer later)

--- a/services/audio/Recorder.ts
+++ b/services/audio/Recorder.ts
@@ -6,14 +6,23 @@ let markers: number[] = [];
 let startTime: number | null = null;
 
 export async function startRecording() {
-	if (recording) return;
-	await Audio.requestPermissionsAsync();
-	await Audio.setAudioModeAsync({ allowsRecordingIOS: true, playsInSilentModeIOS: true });
-	recording = new Audio.Recording();
-		await recording.prepareToRecordAsync(RecordingOptionsPresets.HIGH_QUALITY);
-	await recording.startAsync();
-	markers = [];
-	startTime = Date.now();
+        if (recording) return;
+        try {
+                const { status } = await Audio.requestPermissionsAsync();
+                if (status !== 'granted') {
+                        throw new Error('Recording permission denied');
+                }
+                await Audio.setAudioModeAsync({ allowsRecordingIOS: true, playsInSilentModeIOS: true });
+                const newRecording = new Audio.Recording();
+                await newRecording.prepareToRecordAsync(RecordingOptionsPresets.HIGH_QUALITY);
+                await newRecording.startAsync();
+                recording = newRecording;
+                markers = [];
+                startTime = Date.now();
+        } catch (err: any) {
+                recording = null;
+                throw err instanceof Error ? err : new Error('Failed to start recording');
+        }
 }
 
 export async function stopRecording() {
@@ -35,7 +44,11 @@ export function markAnomaly() {
 }
 
 export function getMarkers() {
-	return markers;
+        return markers;
 }
 
-export default { startRecording, stopRecording, markAnomaly, getMarkers };
+export function isRecording() {
+        return !!recording;
+}
+
+export default { startRecording, stopRecording, markAnomaly, getMarkers, isRecording };


### PR DESCRIPTION
## Summary
- Wrap audio recording setup in try/catch and surface permission errors
- Add `isRecording` getter to expose recording status
- Alert user when recording start fails and sync UI with recording state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb42d96b8832ea56d1b98f3b46927