### PR TITLE
Use SVG logo component for home screen

### DIFF
--- a/assets/Logo.tsx
+++ b/assets/Logo.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import Svg, { Circle, Ellipse, Text } from "react-native-svg";
+import type { SvgProps } from "react-native-svg";
+const SvgLogo = (props: SvgProps) => (
+  <Svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={64}
+    height={64}
+    fill="none"
+    {...props}
+  >
+    <Circle cx={32} cy={32} r={28} stroke="#00E0FF" strokeWidth={4} />
+    <Ellipse cx={32} cy={32} stroke="#7D5CFF" strokeWidth={3} rx={10} ry={18} />
+    <Text
+      x={32}
+      y={38}
+      fill="#E7ECF2"
+      fontFamily="monospace"
+      fontSize={18}
+      textAnchor="middle"
+    >
+      {"0"}
+    </Text>
+  </Svg>
+);
+export default SvgLogo;

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -1,6 +1,7 @@
 
 
-import { View, Text, StyleSheet, Image } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
+import Logo from '../assets/Logo';
 import { useTheme } from '../theme';
 import ParticleField from '../components/fx/ParticleField';
 import EVoidButton from '../components/ui/EVoidButton';
@@ -16,7 +17,7 @@ export default function Home() {
     <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
       <ParticleField />
       <View style={styles.center}>
-        <Image source={require('../assets/logo.svg')} style={{ width: 96, height: 96, marginBottom: 16 }} />
+        <Logo width={96} height={96} style={{ marginBottom: 16 }} />
         <Text style={[styles.title, { color: theme.colors.text }]}>Ech0Void</Text>
         <Text style={[styles.subtitle, { color: theme.colors.accent }]}>where echos become answers</Text>
   <EVoidButton label="Begin Transmission" onPress={() => navigation.navigate('Transmission')} style={styles.btn} />


### PR DESCRIPTION
## Summary
- generate React Native component from assets/logo.svg using SVGR
- render SVG logo component in Home screen instead of Image

## Testing
- `npm test`
- `npm run android` *(fails: expo-dev-client missing)*
- `npm run ios` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb42df0e0832ea194f64fbe545448