### PR TITLE
Add recorder service with echo cancellation and UI

### DIFF
--- a/src/dsp/echo_cancel.ts
+++ b/src/dsp/echo_cancel.ts
@@ -1,0 +1,85 @@
+/**
+ * Simple time domain echo cancellation.
+ * The algorithm subtracts a delayed and attenuated version of the signal
+ * from itself. This is a naive implementation intended for demonstration.
+ */
+export async function applyEchoCancellation(blob: Blob): Promise<Blob> {
+  const arrayBuffer = await blob.arrayBuffer();
+  const audioCtx = new AudioContext();
+  const buffer = await audioCtx.decodeAudioData(arrayBuffer);
+  const out = audioCtx.createBuffer(
+    buffer.numberOfChannels,
+    buffer.length,
+    buffer.sampleRate
+  );
+
+  const delaySamples = Math.floor(0.2 * buffer.sampleRate); // 200ms delay
+  const attenuation = 0.6;
+
+  for (let ch = 0; ch < buffer.numberOfChannels; ch++) {
+    const input = buffer.getChannelData(ch);
+    const output = out.getChannelData(ch);
+    for (let i = 0; i < input.length; i++) {
+      const delayed = i >= delaySamples ? input[i - delaySamples] * attenuation : 0;
+      output[i] = input[i] - delayed;
+    }
+  }
+
+  const processed = await encodeWav(out);
+  return new Blob([processed], { type: 'audio/wav' });
+}
+
+/** Encode an AudioBuffer to a WAV ArrayBuffer. */
+async function encodeWav(buffer: AudioBuffer): Promise<ArrayBuffer> {
+  const numChannels = buffer.numberOfChannels;
+  const sampleRate = buffer.sampleRate;
+  const format = 1; // PCM
+  const bitsPerSample = 16;
+  const numFrames = buffer.length;
+  const blockAlign = numChannels * bitsPerSample / 8;
+  const byteRate = sampleRate * blockAlign;
+  const dataSize = numFrames * blockAlign;
+  const bufferSize = 44 + dataSize;
+  const arrayBuffer = new ArrayBuffer(bufferSize);
+  const view = new DataView(arrayBuffer);
+
+  let offset = 0;
+  function writeString(s: string) {
+    for (let i = 0; i < s.length; i++) {
+      view.setUint8(offset++, s.charCodeAt(i));
+    }
+  }
+  function writeUint32(v: number) {
+    view.setUint32(offset, v, true);
+    offset += 4;
+  }
+  function writeUint16(v: number) {
+    view.setUint16(offset, v, true);
+    offset += 2;
+  }
+
+  writeString('RIFF');
+  writeUint32(bufferSize - 8);
+  writeString('WAVE');
+  writeString('fmt ');
+  writeUint32(16);
+  writeUint16(format);
+  writeUint16(numChannels);
+  writeUint32(sampleRate);
+  writeUint32(byteRate);
+  writeUint16(blockAlign);
+  writeUint16(bitsPerSample);
+  writeString('data');
+  writeUint32(dataSize);
+
+  const temp = new Float32Array(numFrames * numChannels);
+  for (let ch = 0; ch < numChannels; ch++) {
+    temp.set(buffer.getChannelData(ch), ch);
+  }
+  const s16 = new DataView(arrayBuffer, 44);
+  for (let i = 0; i < temp.length; i++) {
+    const sample = Math.max(-1, Math.min(1, temp[i]));
+    s16.setInt16(i * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+  }
+  return arrayBuffer;
+}

--- a/src/recorder/recorder_service.ts
+++ b/src/recorder/recorder_service.ts
@@ -1,0 +1,50 @@
+import { applyEchoCancellation } from '../dsp/echo_cancel';
+
+/**
+ * RecorderService handles microphone input and saves audio files.
+ * This implementation uses the MediaRecorder API available in modern browsers.
+ * Recorded audio is processed with a simple echo cancellation algorithm
+ * before being returned to the caller.
+ */
+export class RecorderService {
+  private mediaRecorder?: MediaRecorder;
+  private chunks: BlobPart[] = [];
+
+  /** Start capturing audio from the microphone. */
+  async start(): Promise<void> {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    this.mediaRecorder = new MediaRecorder(stream);
+    this.chunks = [];
+    this.mediaRecorder.ondataavailable = (e: BlobEvent) => {
+      if (e.data.size > 0) this.chunks.push(e.data);
+    };
+    this.mediaRecorder.start();
+  }
+
+  /**
+   * Stop recording and return a processed audio Blob.
+   * @param filename Optional filename used when triggering a download.
+   */
+  async stop(filename = 'recording.webm'): Promise<Blob> {
+    if (!this.mediaRecorder) throw new Error('Recorder not started');
+
+    const stopped = new Promise<void>((resolve) => {
+      this.mediaRecorder!.onstop = () => resolve();
+    });
+    this.mediaRecorder.stop();
+    await stopped;
+
+    const blob = new Blob(this.chunks, { type: 'audio/webm' });
+    const processed = await applyEchoCancellation(blob);
+    this.chunks = [];
+
+    // Trigger a browser download for the processed file.
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(processed);
+    link.download = filename;
+    link.click();
+    return processed;
+  }
+}
+
+export default new RecorderService();

--- a/src/ui/record_screen.tsx
+++ b/src/ui/record_screen.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import recorder from '../recorder/recorder_service';
+
+/**
+ * Simple UI screen with start and stop buttons for recording.
+ */
+export const RecordScreen: React.FC = () => {
+  const [recording, setRecording] = useState(false);
+
+  const start = async () => {
+    await recorder.start();
+    setRecording(true);
+  };
+
+  const stop = async () => {
+    await recorder.stop();
+    setRecording(false);
+  };
+
+  return (
+    <div>
+      {recording ? (
+        <button onClick={stop}>Stop Recording</button>
+      ) : (
+        <button onClick={start}>Start Recording</button>
+      )}
+    </div>
+  );
+};
+
+export default RecordScreen;


### PR DESCRIPTION
## Summary
- implement recorder service handling microphone input and file saving
- add simple echo cancellation DSP helper
- expose basic record screen UI with start/stop buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb6982608832eb22e29da97a6c72b