### PR TITLE
feat: add cloud upload and sharing

### DIFF
--- a/src/cloud/cloud_service.ts
+++ b/src/cloud/cloud_service.ts
@@ -1,0 +1,49 @@
+export interface CloudProvider {
+  upload(filePath: string): Promise<void>;
+}
+
+/**
+ * Simple placeholder provider. Replace with integration to AWS S3, Firebase, etc.
+ */
+export class DummyProvider implements CloudProvider {
+  async upload(filePath: string): Promise<void> {
+    // In a real implementation this would upload the file to the cloud.
+    console.log(`Uploading ${filePath} to cloud storage...`);
+  }
+}
+
+export interface Settings {
+  /**
+   * When true the recording is automatically uploaded after it is saved.
+   */
+  uploadOnSave: boolean;
+}
+
+// Default runtime settings. In a real app this would be persisted by the user.
+let currentSettings: Settings = {
+  uploadOnSave: false,
+};
+
+export function updateSettings(settings: Partial<Settings>): void {
+  currentSettings = { ...currentSettings, ...settings };
+}
+
+export function getSettings(): Settings {
+  return currentSettings;
+}
+
+/**
+ * Saves a recording and optionally uploads it depending on the current settings.
+ * The actual save functionality is omitted and would be implemented elsewhere.
+ */
+export async function saveRecording(
+  filePath: string,
+  provider: CloudProvider = new DummyProvider(),
+): Promise<void> {
+  // Placeholder for persisting the recording locally.
+  console.log(`Saved recording at ${filePath}`);
+
+  if (currentSettings.uploadOnSave) {
+    await provider.upload(filePath);
+  }
+}

--- a/src/ui/record_detail_screen.tsx
+++ b/src/ui/record_detail_screen.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Button, Share, View } from 'react-native';
+import {
+  saveRecording,
+  getSettings,
+  updateSettings,
+  Settings,
+} from '../cloud/cloud_service';
+
+interface Props {
+  /**
+   * Location of the audio file that this screen is presenting.
+   */
+  filePath: string;
+}
+
+/**
+ * Screen showing details about a recorded audio file.
+ * Users can save the recording and share it with other apps or social media.
+ */
+export const RecordDetailScreen: React.FC<Props> = ({ filePath }) => {
+  const [settings, setSettings] = useState<Settings>(getSettings());
+
+  const onSave = async () => {
+    await saveRecording(filePath);
+  };
+
+  const onShare = async () => {
+    await Share.share({
+      url: filePath,
+      message: 'Check out my recording!',
+    });
+  };
+
+  const toggleUpload = () => {
+    const newValue = !settings.uploadOnSave;
+    updateSettings({ uploadOnSave: newValue });
+    setSettings({ ...settings, uploadOnSave: newValue });
+  };
+
+  return (
+    <View>
+      <Button title="Save" onPress={onSave} />
+      <Button title="Share" onPress={onShare} />
+      <Button
+        title={settings.uploadOnSave ? 'Disable Auto Upload' : 'Enable Auto Upload'}
+        onPress={toggleUpload}
+      />
+    </View>
+  );
+};
+
+export default RecordDetailScreen;


### PR DESCRIPTION
## Summary
- add CloudProvider interface with dummy cloud upload implementation and toggleable settings
- add RecordDetailScreen with save, share, and auto-upload controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb6a16c58832eb12a563c4f563ad0