### PR TITLE
feat: add spectral analysis and anomaly logging

### DIFF
--- a/components/fx/AudioReactiveBars.tsx
+++ b/components/fx/AudioReactiveBars.tsx
@@ -4,32 +4,26 @@ import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-na
 
 const BAR_COUNT = 16;
 
-export default function AudioReactiveBars({ rms = 0.2 }: { rms?: number }) {
-  // Animate bar heights based on rms
-  const [barHeights, setBarHeights] = React.useState<number[]>(Array(BAR_COUNT).fill(0));
-
-  React.useEffect(() => {
-    const interval = setInterval(() => {
-      setBarHeights(generateBarHeights());
-    }, 100);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  const generateBarHeights = () => {
-    return Array.from({ length: BAR_COUNT }, () => Math.random());
-  };
+export default function AudioReactiveBars({ spectrum = [] }: { spectrum?: number[] }) {
+  // Use incoming spectrum data (0..1) to drive bar heights
+  const bars = React.useMemo(() => {
+    const copy = spectrum.slice(0, BAR_COUNT);
+    if (copy.length < BAR_COUNT) {
+      return copy.concat(Array(BAR_COUNT - copy.length).fill(0));
+    }
+    return copy;
+  }, [spectrum]);
 
   return (
     <View style={{ height: 40, width: '100%', flexDirection: 'row', alignItems: 'flex-end', justifyContent: 'center' }}>
-      {barHeights.map((barRms, i) => {
-        const heightVal = useSharedValue(10 + barRms * 60);
+      {bars.map((value, i) => {
+        const heightVal = useSharedValue(10);
         React.useEffect(() => {
-          heightVal.value = withTiming(10 + barRms * 60, { duration: 120 });
-        }, [rms]);
+          heightVal.value = withTiming(10 + value * 60, { duration: 120 });
+        }, [value]);
         const style = useAnimatedStyle(() => ({
           height: heightVal.value,
-          backgroundColor: `rgba(0,224,255,${0.18 + i / BAR_COUNT * 0.5})`,
+          backgroundColor: `rgba(0,224,255,${0.18 + (i / BAR_COUNT) * 0.5})`,
           marginHorizontal: 2,
           borderRadius: 4,
           width: 8,

--- a/screens/LiveITC.tsx
+++ b/screens/LiveITC.tsx
@@ -3,6 +3,8 @@ import { Magnetometer, Accelerometer } from 'expo-sensors';
 import { createEngine, PRESETS } from '../src/core/audio/evpEngine';
 import { WORD_BANK } from '../src/core/audio/wordBank';
 import LiveChain from '../services/audio/LiveChain';
+import SpectralAnalyzer from '../services/audio/spectralAnalyzer';
+import SessionStore from '../services/sessions/SessionStore';
 import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
 import { useTheme } from '../theme';
 import VU from '../components/controls/VU';
@@ -36,11 +38,22 @@ function LiveITC() {
   const [recordingUri, setRecordingUri] = useState<string | null>(null);
   const [playing, setPlaying] = useState(false);
   const [anomalyCount, setAnomalyCount] = useState(0);
+  const [spectrum, setSpectrum] = useState<number[]>(Array(16).fill(0));
+  const anomaliesRef = useRef<number[]>([]);
+  const sessionIdRef = useRef<string | null>(null);
+  const sessionStartRef = useRef<number>(0);
+  const lastPeakRef = useRef<number>(0);
+  const recordingRef = useRef(false);
+  const THRESHOLD = 0.8;
   // Select a random word from the bank
   useEffect(() => {
     const idx = Math.floor(Math.random() * WORD_BANK.length);
     setWord(WORD_BANK[idx]);
   }, []);
+
+  useEffect(() => {
+    recordingRef.current = recording;
+  }, [recording]);
 
   // Sensor subscriptions
   useEffect(() => {
@@ -49,11 +62,40 @@ function LiveITC() {
   return () => { magSub.remove(); accSub.remove(); };
   }, []);
 
-  // Start/stop LiveChain (mic input) when enabled changes
+  // Start/stop LiveChain and spectral analyzer when enabled changes
   useEffect(() => {
-  if (enabled) {
+    if (enabled) {
+      LiveChain.startLiveChain({
+        onLevel: (n) => setVu(n),
+        gain,
+        fx,
+      });
+      liveChainActive.current = true;
+      SpectralAnalyzer.start({
+        fftSize: 512,
+        onSpectrum: (bins) => {
+          setSpectrum(bins.slice(0, 16));
+          const max = Math.max(...bins);
+          setVu(max);
+          setPeak((p) => (max > p ? max : p));
+          if (
+            recordingRef.current &&
+            max > THRESHOLD &&
+            Date.now() - lastPeakRef.current > 1000
+          ) {
+            const t = Date.now() - sessionStartRef.current;
+            anomaliesRef.current.push(t);
+            setAnomalyCount(anomaliesRef.current.length);
+            if (sessionIdRef.current) {
+              SessionStore.appendAnomaly(sessionIdRef.current, t);
+            }
+            lastPeakRef.current = Date.now();
+          }
+        },
+      });
     } else if (liveChainActive.current) {
       LiveChain.stopLiveChain();
+      SpectralAnalyzer.stop();
       liveChainActive.current = false;
       setVu(0);
     }
@@ -62,6 +104,7 @@ function LiveITC() {
         LiveChain.stopLiveChain();
         liveChainActive.current = false;
       }
+      SpectralAnalyzer.stop();
     };
   }, [enabled]);
 
@@ -84,19 +127,30 @@ function LiveITC() {
   }, []);
 
   // Implement recording, anomaly marking, and playback logic
-  const handleRecord = () => {
+  const handleRecord = async () => {
     console.log('Recording started');
+    const id = Date.now().toString();
+    sessionIdRef.current = id;
+    sessionStartRef.current = Date.now();
+    anomaliesRef.current = [];
+    await SessionStore.create({ id, type: 'live', created: Date.now(), anomalies: [] });
+    setAnomalyCount(0);
     setRecording(true);
   };
 
-  const handleStop = () => {
+  const handleStop = async () => {
     console.log('Recording stopped');
     setRecording(false);
+    sessionIdRef.current = null;
   };
 
   const handleMarkAnomaly = () => {
     console.log('Anomaly marked');
-    setAnomalyCount((count) => count + 1);
+    if (!recordingRef.current || !sessionIdRef.current) return;
+    const t = Date.now() - sessionStartRef.current;
+    anomaliesRef.current.push(t);
+    setAnomalyCount(anomaliesRef.current.length);
+    SessionStore.appendAnomaly(sessionIdRef.current, t);
   };
 
   const handlePlay = () => {
@@ -126,7 +180,7 @@ function LiveITC() {
           {word && <Text style={{ color: theme.colors.accent, fontSize: 18, marginTop: 8 }}>ITC Word: {word}</Text>}
         </View>
       </View>
-      <AudioReactiveBars />
+      <AudioReactiveBars spectrum={spectrum} />
       <View style={styles.row}>
         <VU value={vu} peak={peak} />
         <Knob value={gain} onChange={setGain} min={0} max={1} label="Gain" format="" />

--- a/services/audio/spectralAnalyzer.ts
+++ b/services/audio/spectralAnalyzer.ts
@@ -1,0 +1,87 @@
+import { Audio } from 'expo-av';
+
+// Very small FFT implementation (naive DFT) to avoid external deps
+function dft(buffer: Float32Array): number[] {
+  const n = buffer.length;
+  const result: number[] = new Array(Math.floor(n / 2));
+  for (let k = 0; k < result.length; k++) {
+    let re = 0;
+    let im = 0;
+    for (let i = 0; i < n; i++) {
+      const angle = (2 * Math.PI * k * i) / n;
+      re += buffer[i] * Math.cos(angle);
+      im -= buffer[i] * Math.sin(angle);
+    }
+    result[k] = Math.sqrt(re * re + im * im) / n;
+  }
+  return result;
+}
+
+export type SpectrumCallback = (bins: number[]) => void;
+
+let recording: Audio.Recording | null = null;
+let running = false;
+let fftSize = 256;
+let onSpectrum: SpectrumCallback | null = null;
+
+export async function start(opts: { fftSize?: number; onSpectrum: SpectrumCallback }) {
+  if (running) return;
+  fftSize = opts.fftSize ?? 256;
+  onSpectrum = opts.onSpectrum;
+  running = true;
+  await Audio.requestPermissionsAsync();
+  await Audio.setAudioModeAsync({ allowsRecordingIOS: true, playsInSilentModeIOS: true });
+  recording = new Audio.Recording();
+  await recording.prepareToRecordAsync({
+    android: {
+      extension: '.wav',
+      outputFormat: Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_PCM_16BIT,
+      audioEncoder: Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_PCM_16BIT,
+      sampleRate: 44100,
+      numberOfChannels: 1,
+      bitRate: 128000,
+    },
+    ios: {
+      extension: '.caf',
+      outputFormat: Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_LINEARPCM,
+      audioQuality: Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_MIN,
+      sampleRate: 44100,
+      numberOfChannels: 1,
+      linearPCMBitDepth: 16,
+      linearPCMIsBigEndian: false,
+      linearPCMIsFloat: false,
+    },
+    web: {
+      mimeType: 'audio/webm',
+      bitsPerSecond: 128000,
+    },
+    isMeteringEnabled: true,
+  });
+
+  // @ts-ignore Expo SDK provides this for getting PCM data
+  (recording as any).setOnRecordingStatusUpdate?.((status: any) => {
+    const pcm = status?.samples as Float32Array | undefined;
+    if (!pcm || pcm.length < fftSize) return;
+    const slice = pcm.slice(0, fftSize);
+    const spectrum = dft(slice);
+    const max = Math.max(...spectrum) || 1;
+    onSpectrum?.(spectrum.map((v) => v / max));
+  });
+
+  await recording.startAsync();
+}
+
+export async function stop() {
+  running = false;
+  onSpectrum = null;
+  if (recording) {
+    try {
+      // @ts-ignore clear callback if available
+      recording.setOnRecordingStatusUpdate?.(null);
+      await recording.stopAndUnloadAsync();
+    } catch {}
+    recording = null;
+  }
+}
+
+export default { start, stop };

--- a/services/sessions/SessionStore.ts
+++ b/services/sessions/SessionStore.ts
@@ -67,6 +67,24 @@ async function update(id: string, data: any) {
   }
 }
 
+async function appendAnomaly(id: string, ms: number) {
+  try {
+    const sessions = await list();
+    const idx = sessions.findIndex((s: any) => s.id === id);
+    if (idx !== -1) {
+      const sess = sessions[idx];
+      sess.anomalies = sess.anomalies || [];
+      sess.anomalies.push(ms);
+      await AsyncStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
+      return true;
+    }
+    return false;
+  } catch (error) {
+    console.error('Failed to append anomaly:', error);
+    throw error;
+  }
+}
+
 async function deleteMedia(sessionId: string) {
   try {
     const mediaPath = `${MEDIA_DIR}${sessionId}/`;
@@ -98,4 +116,5 @@ export default {
   update,
   delete: _delete,
   list,
+  appendAnomaly,
 };


### PR DESCRIPTION
## Summary
- add spectral analyzer service using naive FFT over expo-av audio
- drive AudioReactiveBars with live spectrum data
- detect spectral peaks in LiveITC and persist anomalies to SessionStore

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aebe46f450832eba0f69ca49f612a1