### PR TITLE
feat: add session sync and controls

### DIFF
--- a/services/sessions/SessionStore.ts
+++ b/services/sessions/SessionStore.ts
@@ -4,20 +4,35 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as FileSystem from 'expo-file-system';
 
+export type SyncStatus = 'offline' | 'connecting' | 'online';
+
+export interface Session {
+  id: string;
+  participants: string[];
+  syncStatus: SyncStatus;
+  media?: string[];
+  [key: string]: any;
+}
+
 const SESSIONS_KEY = 'sessions';
 const MEDIA_DIR = `${FileSystem.documentDirectory}media/`;
 
 // Add error handling for session operations
-async function create(session: any) {
+async function create(session: Session) {
   try {
     const sessions = await list();
-    sessions.push(session);
+    const newSession: Session = {
+      participants: [],
+      syncStatus: 'offline',
+      ...session,
+    };
+    sessions.push(newSession);
     await AsyncStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
 
-    if (session.media) {
+    if (newSession.media) {
       const mediaPath = `${MEDIA_DIR}${session.id}/`;
       await FileSystem.makeDirectoryAsync(mediaPath, { intermediates: true });
-      for (const file of session.media) {
+      for (const file of newSession.media) {
         try {
           await FileSystem.copyAsync({ from: file, to: `${mediaPath}${file.split('/').pop()}` });
         } catch (fileError) {
@@ -31,30 +46,35 @@ async function create(session: any) {
   }
 }
 
-async function list() {
+async function list(): Promise<Session[]> {
   try {
     const raw = await AsyncStorage.getItem(SESSIONS_KEY);
-    return raw ? JSON.parse(raw) : [];
+    const sessions: Session[] = raw ? JSON.parse(raw) : [];
+    return sessions.map((s) => ({
+      participants: [],
+      syncStatus: 'offline',
+      ...s,
+    }));
   } catch (error) {
     console.error('Failed to list sessions:', error);
     return [];
   }
 }
 
-async function read(id: string) {
+async function read(id: string): Promise<Session | null> {
   try {
     const sessions = await list();
-    return sessions.find((s: any) => s.id === id) || null;
+    return sessions.find((s: Session) => s.id === id) || null;
   } catch (error) {
     console.error('Failed to read session:', error);
     return null;
   }
 }
 
-async function update(id: string, data: any) {
+async function update(id: string, data: Partial<Session>) {
   try {
     const sessions = await list();
-    const idx = sessions.findIndex((s: any) => s.id === id);
+    const idx = sessions.findIndex((s: Session) => s.id === id);
     if (idx !== -1) {
       sessions[idx] = { ...sessions[idx], ...data };
       await AsyncStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
@@ -82,7 +102,7 @@ async function deleteMedia(sessionId: string) {
 async function _delete(id: string) {
   try {
     const sessions = await list();
-    const filtered = sessions.filter((s: any) => s.id !== id);
+    const filtered = sessions.filter((s: Session) => s.id !== id);
     await AsyncStorage.setItem(SESSIONS_KEY, JSON.stringify(filtered));
     await deleteMedia(id);
     return true;

--- a/services/sessions/SessionSync.ts
+++ b/services/sessions/SessionSync.ts
@@ -1,0 +1,112 @@
+import { EventEmitter } from 'events';
+
+export type SyncStatus = 'offline' | 'connecting' | 'online';
+
+/**
+ * SessionSync handles realtime exchange of data between session participants
+ * over a WebSocket connection. It provides basic reconnection logic and
+ * falls back to queuing messages when offline.
+ */
+export default class SessionSync extends EventEmitter {
+  private ws: WebSocket | null = null;
+  private readonly sessionId: string;
+  private readonly isHost: boolean;
+  private readonly url: string;
+  private reconnectTimer: any;
+  private readonly reconnectInterval = 5000;
+  private manualClose = false;
+  private queue: string[] = [];
+
+  public status: SyncStatus = 'offline';
+  public participants: string[] = [];
+
+  constructor(sessionId: string, isHost: boolean, url = 'wss://echo.websocket.events') {
+    super();
+    this.sessionId = sessionId;
+    this.isHost = isHost;
+    this.url = url;
+  }
+
+  /** Establish the socket connection */
+  connect() {
+    this.status = 'connecting';
+    this.emit('status', this.status);
+
+    try {
+      this.ws = new WebSocket(this.url);
+
+      this.ws.onopen = () => {
+        this.status = 'online';
+        this.emit('status', this.status);
+        this.flushQueue();
+        // announce join/host
+        const payload = { type: this.isHost ? 'host' : 'join', sessionId: this.sessionId };
+        this.ws?.send(JSON.stringify(payload));
+      };
+
+      this.ws.onmessage = (event: any) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === 'participants') {
+            this.participants = data.participants;
+            this.emit('participants', this.participants);
+          } else {
+            this.emit('message', data);
+          }
+        } catch {
+          this.emit('message', event.data);
+        }
+      };
+
+      this.ws.onclose = () => {
+        this.status = 'offline';
+        this.emit('status', this.status);
+        if (!this.manualClose) {
+          clearTimeout(this.reconnectTimer);
+          this.reconnectTimer = setTimeout(() => this.connect(), this.reconnectInterval);
+        }
+      };
+
+      this.ws.onerror = () => {
+        this.status = 'offline';
+        this.emit('status', this.status);
+      };
+    } catch {
+      this.status = 'offline';
+      this.emit('status', this.status);
+    }
+  }
+
+  /** Send data through the socket. If offline, queue messages for later. */
+  send(data: any) {
+    const payload = JSON.stringify(data);
+    if (!this.ws || this.status !== 'online') {
+      this.queue.push(payload);
+      return;
+    }
+    try {
+      this.ws.send(payload);
+    } catch {
+      this.queue.push(payload);
+    }
+  }
+
+  private flushQueue() {
+    while (this.queue.length && this.ws && this.status === 'online') {
+      this.ws.send(this.queue.shift() as string);
+    }
+  }
+
+  /** Close the socket connection */
+  disconnect() {
+    this.manualClose = true;
+    clearTimeout(this.reconnectTimer);
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.status = 'offline';
+    this.emit('status', this.status);
+  }
+}
+

--- a/src/screens/TransmissionScreen.tsx
+++ b/src/screens/TransmissionScreen.tsx
@@ -1,18 +1,72 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  Button,
+  FlatList,
+} from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme/colors';
+import SessionSync from '../../services/sessions/SessionSync';
+import SessionStore from '../../services/sessions/SessionStore';
 
 // Added type annotation for navigation prop
 const TransmissionScreen = ({ navigation }: { navigation: any }) => {
   // Log navigation prop
   console.log('[TransmissionScreen] navigation prop:', navigation);
 
+  const [sessionId, setSessionId] = useState('');
+  const [participants, setParticipants] = useState<string[]>([]);
+  const [status, setStatus] = useState<'offline' | 'connecting' | 'online'>('offline');
+  const syncRef = useRef<SessionSync | null>(null);
+
+  const handleHost = async () => {
+    const sync = new SessionSync(sessionId, true);
+    syncRef.current = sync;
+    sync.on('participants', async (p: string[]) => {
+      setParticipants(p);
+      await SessionStore.update(sessionId, { participants: p });
+    });
+    sync.on('status', async (s) => {
+      setStatus(s);
+      await SessionStore.update(sessionId, { syncStatus: s });
+    });
+    await SessionStore.create({ id: sessionId });
+    sync.connect();
+  };
+
+  const handleJoin = () => {
+    const sync = new SessionSync(sessionId, false);
+    syncRef.current = sync;
+    sync.on('participants', setParticipants);
+    sync.on('status', setStatus);
+    sync.connect();
+  };
+
   return (
     <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
       <View style={styles.container}>
         <Text style={styles.h1}>Transmission</Text>
-        <Text style={styles.p}>Listening / responses will appear here.</Text>
+        <TextInput
+          placeholder="Session ID"
+          placeholderTextColor={colors.subtext}
+          style={styles.input}
+          value={sessionId}
+          onChangeText={setSessionId}
+        />
+        <View style={styles.buttonRow}>
+          <Button title="Host" onPress={handleHost} />
+          <Button title="Join" onPress={handleJoin} />
+        </View>
+        <Text style={styles.status}>Status: {status}</Text>
+        <FlatList
+          data={participants}
+          keyExtractor={(item) => item}
+          renderItem={({ item }) => <Text style={styles.participant}>{item}</Text>}
+          ListEmptyComponent={<Text style={styles.p}>No participants</Text>}
+        />
       </View>
     </LinearGradient>
   );
@@ -22,6 +76,25 @@ const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
   h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
   p: { color: colors.subtext, marginTop: 8 },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.subtext,
+    padding: 8,
+    marginTop: 16,
+    color: colors.text,
+    width: '100%',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+    marginTop: 16,
+  },
+  participant: {
+    color: colors.text,
+    marginTop: 4,
+  },
+  status: { color: colors.subtext, marginTop: 16, marginBottom: 8 },
 });
 
 export default TransmissionScreen;


### PR DESCRIPTION
## Summary
- add WebSocket-based session sync module with reconnection
- track session participants and sync status in storage
- add host/join controls showing participants on transmission screen

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE, ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68aebe579d98832e836a801dac38598c