### PR TITLE
feat: add prompt system with tts controls

### DIFF
--- a/services/sessions/SessionStore.ts
+++ b/services/sessions/SessionStore.ts
@@ -92,10 +92,29 @@ async function _delete(id: string) {
   }
 }
 
+async function appendPrompt(id: string, text: string) {
+  try {
+    const sessions = await list();
+    const idx = sessions.findIndex((s: any) => s.id === id);
+    if (idx !== -1) {
+      const prompts = sessions[idx].prompts || [];
+      prompts.push({ text, at: Date.now() });
+      sessions[idx].prompts = prompts;
+      await AsyncStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
+      return true;
+    }
+    return false;
+  } catch (error) {
+    console.error('Failed to append prompt:', error);
+    return false;
+  }
+}
+
 export default {
   create,
   read,
   update,
   delete: _delete,
   list,
+  appendPrompt,
 };

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -1,0 +1,28 @@
+export const PROMPT_THEMES: Record<string, string[]> = {
+  identity: [
+    'Who are you?',
+    'What is your name?',
+    'Are you human?',
+  ],
+  presence: [
+    'Are you here with us?',
+    'Why are you here?',
+    'Can you show a sign?'
+  ],
+  time: [
+    'What year is it for you?',
+    'How long have you been here?',
+    'Do you remember the day you left?'
+  ],
+};
+
+const FLAT_PROMPTS = Object.values(PROMPT_THEMES).flat();
+let promptIndex = 0;
+
+export function nextPrompt(): string {
+  if (FLAT_PROMPTS.length === 0) return '';
+  const q = FLAT_PROMPTS[promptIndex % FLAT_PROMPTS.length];
+  promptIndex += 1;
+  return q;
+}
+

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,23 +1,64 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Switch } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import Slider from '@react-native-community/slider';
 import { colors } from '../theme/colors';
+import { useEsmera } from '../../services/tts/Esmera';
+import { usePrefs } from '../../hooks/usePrefs';
+import Toggle from '../components/Toggle';
 
 export default function SettingsScreen({ navigation }: { navigation: any }) {
   // Log navigation prop
   console.log('[SettingsScreen] navigation prop:', navigation);
 
+  const { availableVoices } = useEsmera();
+  const [promptsEnabled, setPromptsEnabled] = usePrefs('prompts.enabled', true);
+  const [voiceId, setVoiceId] = usePrefs('prompts.voice', '');
+  const [rate, setRate] = usePrefs('prompts.rate', 1);
+  const [pitch, setPitch] = usePrefs('prompts.pitch', 1);
+
   return (
     <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
       <View style={styles.container}>
         <Text style={styles.h1}>Settings</Text>
-        <Text style={styles.p}>(Add prefs like voice, theme, logging here)</Text>
+
+        <View style={styles.row}>
+          <Text style={styles.label}>Enable Prompts</Text>
+          <Switch value={promptsEnabled} onValueChange={setPromptsEnabled} />
+        </View>
+
+        <Text style={styles.section}>Voice</Text>
+        <View style={styles.rowWrap}>
+          {availableVoices.map(v => (
+            <Toggle key={v.identifier} label={v.name} active={voiceId === v.identifier} onPress={() => setVoiceId(v.identifier)} />
+          ))}
+        </View>
+
+        <Text style={styles.section}>Rate: {rate.toFixed(2)}</Text>
+        <Slider
+          minimumValue={0.5}
+          maximumValue={2}
+          value={rate}
+          onValueChange={setRate}
+        />
+
+        <Text style={styles.section}>Pitch: {pitch.toFixed(2)}</Text>
+        <Slider
+          minimumValue={0.5}
+          maximumValue={2}
+          value={pitch}
+          onValueChange={setPitch}
+        />
       </View>
     </LinearGradient>
   );
 }
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
+  container: { flex: 1, padding: 24 },
+  h1: { color: colors.text, fontSize: 28, fontWeight: '700', textAlign: 'center', marginBottom: 24 },
   p: { color: colors.subtext, marginTop: 8 },
+  row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24 },
+  label: { color: colors.text, fontSize: 16 },
+  section: { color: colors.text, fontSize: 18, marginTop: 16, marginBottom: 8 },
+  rowWrap: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 24 },
 });

--- a/src/screens/TransmissionScreen.tsx
+++ b/src/screens/TransmissionScreen.tsx
@@ -1,18 +1,44 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme/colors';
+import UIButton from '../components/UIButton';
+import { nextPrompt } from '../core/prompts';
+import { useEsmera } from '../../services/tts/Esmera';
+import { usePrefs } from '../../hooks/usePrefs';
+import { useSession } from '../context/SessionContext';
+import SessionStore from '../../services/sessions/SessionStore';
 
 // Added type annotation for navigation prop
 const TransmissionScreen = ({ navigation }: { navigation: any }) => {
   // Log navigation prop
   console.log('[TransmissionScreen] navigation prop:', navigation);
 
+  const { speak } = useEsmera();
+  const { session } = useSession();
+  const [promptsEnabled] = usePrefs('prompts.enabled', true);
+  const [voiceId] = usePrefs('prompts.voice', '');
+  const [rate] = usePrefs('prompts.rate', 1);
+  const [pitch] = usePrefs('prompts.pitch', 1);
+
+  const [current, setCurrent] = useState('');
+
+  const onPrompt = () => {
+    const q = nextPrompt();
+    setCurrent(q);
+    speak(q, { voiceId, rate, pitch });
+    if (session) {
+      SessionStore.appendPrompt(session.id, q).catch(() => {});
+    }
+  };
+
   return (
     <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
       <View style={styles.container}>
         <Text style={styles.h1}>Transmission</Text>
         <Text style={styles.p}>Listening / responses will appear here.</Text>
+        {promptsEnabled && <UIButton label="Prompt" onPress={onPrompt} style={{ marginTop: 24 }} />}
+        {current ? <Text style={styles.prompt}>{current}</Text> : null}
       </View>
     </LinearGradient>
   );
@@ -22,6 +48,7 @@ const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
   h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
   p: { color: colors.subtext, marginTop: 8 },
+  prompt: { color: colors.text, marginTop: 16, fontStyle: 'italic', textAlign: 'center' },
 });
 
 export default TransmissionScreen;


### PR DESCRIPTION
## Summary
- add themed prompt library and sequence helper
- enable spoken prompts on Transmission screen
- expose TTS settings and prompt toggle
- log used prompts into sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aebf0a5bc4832e8e1e077d9551017e