### PR TITLE
feat(ar): add energy heatmap and session spike logging

### DIFF
--- a/components/fx/EnergyHeatmap.tsx
+++ b/components/fx/EnergyHeatmap.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+
+interface Props {
+  magnetometer: number[];
+  accelerometer: number[];
+  sensitivity: number;
+  windowSize?: number;
+  onSpike?: (variance: number) => void;
+}
+
+export default function EnergyHeatmap({ magnetometer, accelerometer, sensitivity, windowSize = 10, onSpike }: Props) {
+  const magHistory = useRef<number[]>([]);
+  const accHistory = useRef<number[]>([]);
+  const [intensity, setIntensity] = useState(0);
+
+  useEffect(() => {
+    const magMag = Math.sqrt(magnetometer.reduce((s, v) => s + v * v, 0));
+    const accMag = Math.sqrt(accelerometer.reduce((s, v) => s + v * v, 0));
+
+    magHistory.current.push(magMag);
+    if (magHistory.current.length > windowSize) magHistory.current.shift();
+    accHistory.current.push(accMag);
+    if (accHistory.current.length > windowSize) accHistory.current.shift();
+
+    const magAvg = magHistory.current.reduce((a, b) => a + b, 0) / magHistory.current.length;
+    const accAvg = accHistory.current.reduce((a, b) => a + b, 0) / accHistory.current.length;
+
+    const variance = Math.abs(magMag - magAvg) + Math.abs(accMag - accAvg);
+    const scaled = Math.min(1, variance / sensitivity);
+    setIntensity(scaled);
+
+    if (variance > sensitivity) {
+      onSpike?.(variance);
+    }
+  }, [magnetometer, accelerometer, sensitivity, windowSize, onSpike]);
+
+  return <View pointerEvents="none" style={[styles.overlay, { backgroundColor: `rgba(255,0,0,${intensity})` }]} />;
+}
+
+const styles = StyleSheet.create({
+  overlay: { ...StyleSheet.absoluteFillObject },
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-file-system": "~18.1.11",
         "expo-gl": "~15.1.7",
         "expo-linear-gradient": "~14.1.5",
+        "expo-location": "~18.1.0",
         "expo-mail-composer": "~14.1.5",
         "expo-router": "~5.1.4",
         "expo-sensors": "~14.1.4",
@@ -5548,6 +5549,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "18.1.6",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.1.6.tgz",
+      "integrity": "sha512-l5dQQ2FYkrBgNzaZN1BvSmdhhcztFOUucu2kEfDBMV4wSIuTIt/CKsho+F3RnAiWgvui1wb1WTTf80E8zq48hA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-mail-composer": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "expo-mail-composer": "~14.1.5",
     "expo-router": "~5.1.4",
     "expo-sensors": "~14.1.4",
+    "expo-location": "~18.1.0",
     "expo-sharing": "~13.1.5",
     "expo-speech": "~13.1.7",
     "expo-three": "^2.2.1",

--- a/services/sessions/SessionStore.ts
+++ b/services/sessions/SessionStore.ts
@@ -67,6 +67,23 @@ async function update(id: string, data: any) {
   }
 }
 
+async function addSpike(id: string, spike: any) {
+  try {
+    const sessions = await list();
+    const idx = sessions.findIndex((s: any) => s.id === id);
+    if (idx !== -1) {
+      if (!sessions[idx].spikes) sessions[idx].spikes = [];
+      sessions[idx].spikes.push(spike);
+      await AsyncStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
+      return true;
+    }
+    return false;
+  } catch (error) {
+    console.error('Failed to record spike:', error);
+    return false;
+  }
+}
+
 async function deleteMedia(sessionId: string) {
   try {
     const mediaPath = `${MEDIA_DIR}${sessionId}/`;
@@ -96,6 +113,7 @@ export default {
   create,
   read,
   update,
+  addSpike,
   delete: _delete,
   list,
 };

--- a/src/screens/ARModeScreen.tsx
+++ b/src/screens/ARModeScreen.tsx
@@ -5,6 +5,10 @@ import { Camera as ExpoCamera, CameraType, useCameraPermissions } from 'expo-cam
 import { GLView } from 'expo-gl';
 import { Renderer } from 'expo-three';
 import * as THREE from 'three';
+import EnergyHeatmap from '../../components/fx/EnergyHeatmap';
+import EVoidSlider from '../../components/controls/Slider';
+import SessionStore from '../../services/sessions/SessionStore';
+import * as Location from 'expo-location';
 import { colors } from '../theme/colors';
 
 const { width, height } = Dimensions.get('window');
@@ -13,6 +17,8 @@ export default function ARModeScreen({ navigation }: any) {
   const [mag, setMag] = useState([0, 0, 0]);
   const [acc, setAcc] = useState([0, 0, 0]);
   const [light, setLight] = useState(0);
+  const [sensitivity, setSensitivity] = useState(1);
+  const [sessionId, setSessionId] = useState<string | null>(null);
   const [permission, requestPermission] = useCameraPermissions();
   const hasPermission = permission?.granted ?? false;
   const cameraRef = useRef(null);
@@ -32,6 +38,42 @@ export default function ARModeScreen({ navigation }: any) {
       if (lightSub) lightSub.remove();
     };
   }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        await Location.requestForegroundPermissionsAsync();
+        const session = {
+          id: Date.now().toString(),
+          type: 'ar',
+          date: new Date().toISOString(),
+          spikes: [],
+        };
+        await SessionStore.create(session);
+        setSessionId(session.id);
+      } catch (e) {
+        console.error('Failed to initialize AR session', e);
+      }
+    })();
+  }, []);
+
+  const handleSpike = async (variance: number) => {
+    try {
+      const { coords } = await Location.getCurrentPositionAsync({});
+      if (sessionId) {
+        await SessionStore.addSpike(sessionId, {
+          timestamp: new Date().toISOString(),
+          location: {
+            latitude: coords.latitude,
+            longitude: coords.longitude,
+          },
+          variance,
+        });
+      }
+    } catch (e) {
+      console.error('Failed to record spike', e);
+    }
+  };
 
   // Log navigation prop
   console.log('[ARModeScreen] navigation prop:', navigation);
@@ -71,12 +113,27 @@ export default function ARModeScreen({ navigation }: any) {
         style={StyleSheet.absoluteFill}
         onContextCreate={onContextCreate}
       />
+      <EnergyHeatmap
+        magnetometer={mag}
+        accelerometer={acc}
+        sensitivity={sensitivity}
+        onSpike={handleSpike}
+      />
       <View style={styles.overlay} pointerEvents="box-none">
         <Text style={styles.h1}>AR Mode</Text>
         <Text style={styles.p}>Magnetometer: {mag.map((v) => v.toFixed(2)).join(', ')}</Text>
         <Text style={styles.p}>Accelerometer: {acc.map((v) => v.toFixed(2)).join(', ')}</Text>
         <Text style={styles.p}>Light: {light ? light.toFixed(2) : 'n/a'} lux</Text>
         <Text style={styles.p}>(3D compass overlays camera, reacts to sensors)</Text>
+        <EVoidSlider
+          value={sensitivity}
+          onChange={setSensitivity}
+          min={0.1}
+          max={5}
+          step={0.1}
+          label="Sensitivity"
+          format=""
+        />
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
- overlay energy heatmap reacting to magnetometer and accelerometer variance
- add sensitivity controls and session spike recording with location
- support spike recording in session store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aebf65e570832ebcec6e73f4da2e8c