### PR TITLE
feat: add design system and new themes

### DIFF
--- a/components/logbook/SessionDetail.tsx
+++ b/components/logbook/SessionDetail.tsx
@@ -3,11 +3,15 @@ import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { Audio } from 'expo-av';
 import EVoidButton from '../ui/EVoidButton';
 import { shareSessionZip } from '../../services/export/zipSession';
+import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 export default function SessionDetail({ route }: any) {
   const session = route?.params?.session;
   const [playing, setPlaying] = useState(false);
   const soundRef = useRef<Audio.Sound | null>(null);
+  const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
 
   const handlePlay = async () => {
     if (!session?.uri) return;
@@ -34,8 +38,14 @@ export default function SessionDetail({ route }: any) {
     } catch {}
   };
 
+  const styles = StyleSheet.create({
+    detail: { flex: 1, padding: spacing.xl, backgroundColor: theme.colors.bg },
+    title: { ...typography.h2, color: theme.colors.text, marginBottom: spacing.lg },
+    label: { color: theme.colors.text + '99', ...typography.label, marginTop: spacing.md },
+    value: { color: theme.colors.text, fontSize: 15, marginTop: spacing.xs },
+  });
   return (
-    <ScrollView style={styles.detail} contentContainerStyle={{ paddingBottom: 40 }}>
+    <ScrollView style={styles.detail} contentContainerStyle={{ paddingBottom: spacing.xxxl }}>
       <Text style={styles.title}>Session Detail</Text>
       <Text style={styles.label}>Type:</Text>
       <Text style={styles.value}>{session?.type || 'Session'}</Text>
@@ -46,7 +56,7 @@ export default function SessionDetail({ route }: any) {
       <EVoidButton
         label={playing ? 'Stop Playback' : 'Play Recording'}
         onPress={handlePlay}
-        style={{ marginVertical: 16, minWidth: 140 }}
+        style={{ marginVertical: spacing.lg, minWidth: 140 }}
       />
       <Text style={styles.label}>Anomaly Timestamps:</Text>
       {session?.anomalies?.length ? (
@@ -56,13 +66,7 @@ export default function SessionDetail({ route }: any) {
       ) : (
         <Text style={styles.value}>None</Text>
       )}
-  <EVoidButton label="Export Session" onPress={() => shareSessionZip(session)} style={{ marginTop: 24 }} />
+      <EVoidButton label="Export Session" onPress={() => shareSessionZip(session)} style={{ marginTop: spacing.xxl }} />
     </ScrollView>
   );
 }
-const styles = StyleSheet.create({
-  detail: { flex: 1, padding: 20, backgroundColor: '#111' },
-  title: { fontSize: 24, fontWeight: '800', color: '#fff', marginBottom: 16 },
-  label: { color: '#aaa', fontWeight: '600', marginTop: 12 },
-  value: { color: '#fff', fontSize: 15, marginTop: 2 },
-});

--- a/components/logbook/SessionItem.tsx
+++ b/components/logbook/SessionItem.tsx
@@ -1,7 +1,20 @@
 import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 // TODO: Show session summary, type, date, and quick actions
 export default function SessionItem({ session, onDelete, onView }: { session: any; onDelete: () => void; onView: () => void }) {
+  const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    item: { padding: spacing.lg, borderRadius: spacing.md, backgroundColor: theme.colors.surface, marginVertical: spacing.sm },
+    type: { ...typography.body, fontWeight: '700', color: theme.colors.text },
+    date: { ...typography.caption, color: theme.colors.text + '99', marginTop: spacing.xs },
+    info: { ...typography.caption, color: theme.colors.accent, marginTop: spacing.xs },
+    actions: { flexDirection: 'row', marginTop: spacing.sm },
+    actionButton: { marginRight: spacing.md, padding: spacing.sm, backgroundColor: theme.colors.surface, borderRadius: spacing.sm },
+    actionText: { ...typography.caption, color: theme.colors.text },
+  });
   return (
     <View style={styles.item}>
       <Text style={styles.type}>{session.type || 'Session'}</Text>
@@ -14,12 +27,3 @@ export default function SessionItem({ session, onDelete, onView }: { session: an
     </View>
   );
 }
-const styles = StyleSheet.create({
-  item: { padding: 16, borderRadius: 12, backgroundColor: '#222', marginVertical: 6 },
-  type: { color: '#fff', fontWeight: '700', fontSize: 16 },
-  date: { color: '#aaa', fontSize: 13, marginTop: 2 },
-  info: { color: '#8ff', fontSize: 13, marginTop: 4 },
-  actions: { flexDirection: 'row', marginTop: 8 },
-  actionButton: { marginRight: 12, padding: 8, backgroundColor: '#444', borderRadius: 8 },
-  actionText: { color: '#fff', fontSize: 13 },
-});

--- a/components/ui/EVoidButton.tsx
+++ b/components/ui/EVoidButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 type Props = {
   label: string;
@@ -13,11 +14,22 @@ type Props = {
 
 export default function EVoidButton({ label, onPress, variant = 'solid', style, testID, disabled = false }: Props) {
   const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    btn: {
+      paddingVertical: spacing.lg,
+      paddingHorizontal: spacing.xl,
+      borderRadius: spacing.lg,
+      alignItems: 'center',
+      marginVertical: spacing.xs,
+    },
+    text: { ...typography.button },
+  });
   return (
     <Pressable
       testID={testID}
       accessibilityRole="button"
-      hitSlop={12}
+      hitSlop={spacing.sm}
       onPress={disabled ? undefined : onPress}
       style={({ pressed }) => [
         styles.btn,
@@ -35,7 +47,3 @@ export default function EVoidButton({ label, onPress, variant = 'solid', style, 
     </Pressable>
   );
 }
-const styles = StyleSheet.create({
-  btn: { paddingVertical: 14, paddingHorizontal: 20, borderRadius: 14, alignItems: 'center', marginVertical: 4 },
-  text: { fontSize: 16, fontWeight: '700', letterSpacing: 0.4 },
-});

--- a/components/ui/EVoidCard.tsx
+++ b/components/ui/EVoidCard.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { View, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 type Props = { children: React.ReactNode; style?: ViewStyle | ViewStyle[] };
 export default function EVoidCard({ children, style }: Props) {
   const { theme } = useTheme();
-  return <View style={[styles.card, { backgroundColor: theme.colors.surface, shadowColor: theme.colors.bg }, style]}>{children}</View>;
+  const { spacing, elevation } = useDesignSystem();
+  const styles = StyleSheet.create({
+    card: {
+      borderRadius: spacing.lg,
+      padding: spacing.lg,
+      margin: spacing.sm,
+      ...elevation.low,
+      shadowColor: theme.colors.bg,
+    },
+  });
+  return <View style={[styles.card, style]}>{children}</View>;
 }
-const styles = StyleSheet.create({
-  card: { borderRadius: 16, padding: 16, margin: 8, shadowOpacity: 0.15, shadowRadius: 8, shadowOffset: { width: 0, height: 2 } },
-});

--- a/components/ui/EVoidChip.tsx
+++ b/components/ui/EVoidChip.tsx
@@ -1,17 +1,24 @@
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 type Props = { label: string; selected?: boolean; style?: ViewStyle | ViewStyle[] };
 export default function EVoidChip({ label, selected, style }: Props) {
   const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    chip: {
+      paddingVertical: spacing.sm,
+      paddingHorizontal: spacing.lg,
+      borderRadius: spacing.lg,
+      margin: spacing.xs,
+    },
+    text: { ...typography.chip },
+  });
   return (
     <View style={[styles.chip, { backgroundColor: selected ? theme.colors.accent : theme.colors.surface }, style]}>
       <Text style={[styles.text, { color: selected ? theme.colors.bg : theme.colors.text }]}>{label}</Text>
     </View>
   );
 }
-const styles = StyleSheet.create({
-  chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 4 },
-  text: { fontWeight: '600', fontSize: 14 },
-});

--- a/components/ui/EVoidDialog.tsx
+++ b/components/ui/EVoidDialog.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import { Modal, View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 type Props = { visible: boolean; title: string; children: React.ReactNode; onClose: () => void };
 export default function EVoidDialog({ visible, title, children, onClose }: Props) {
   const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    overlay: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    dialog: { borderRadius: spacing.xl, padding: spacing.xxl, minWidth: 260 },
+    title: { ...typography.title, marginBottom: spacing.md },
+  });
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <View style={styles.overlay}>
+      <View style={[styles.overlay, { backgroundColor: theme.colors.bg + '99' }]}> 
         <View style={[styles.dialog, { backgroundColor: theme.colors.surface }]}> 
           <Text style={[styles.title, { color: theme.colors.text }]}>{title}</Text>
           {children}
@@ -16,8 +23,3 @@ export default function EVoidDialog({ visible, title, children, onClose }: Props
     </Modal>
   );
 }
-const styles = StyleSheet.create({
-  overlay: { flex: 1, backgroundColor: '#0009', justifyContent: 'center', alignItems: 'center' },
-  dialog: { borderRadius: 18, padding: 24, minWidth: 260 },
-  title: { fontWeight: '700', fontSize: 18, marginBottom: 12 },
-});

--- a/components/ui/EVoidListItem.tsx
+++ b/components/ui/EVoidListItem.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 type Props = { title: string; subtitle?: string; right?: React.ReactNode; style?: ViewStyle | ViewStyle[] };
 export default function EVoidListItem({ title, subtitle, right, style }: Props) {
   const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    item: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: spacing.lg,
+      borderRadius: spacing.md,
+      marginVertical: spacing.xs,
+    },
+    title: { ...typography.body, fontWeight: '700' },
+    subtitle: { ...typography.caption, marginTop: spacing.xs },
+  });
   return (
     <View style={[styles.item, { backgroundColor: theme.colors.surface }, style]}>
       <View style={{ flex: 1 }}>
@@ -15,8 +28,3 @@ export default function EVoidListItem({ title, subtitle, right, style }: Props) 
     </View>
   );
 }
-const styles = StyleSheet.create({
-  item: { flexDirection: 'row', alignItems: 'center', padding: 16, borderRadius: 12, marginVertical: 4 },
-  title: { fontWeight: '700', fontSize: 16 },
-  subtitle: { fontSize: 13, marginTop: 2 },
-});

--- a/components/ui/EVoidSlider.tsx
+++ b/components/ui/EVoidSlider.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 type Props = { value: number; onValueChange: (v: number) => void; min?: number; max?: number; step?: number; label?: string };
 export default function EVoidSlider({ value, onValueChange, min = 0, max = 1, step = 0.01, label }: Props) {
   const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    wrap: { width: '100%', marginVertical: spacing.sm },
+    label: { ...typography.label, marginBottom: spacing.xs },
+    slider: { width: '100%' },
+  });
   return (
     <View style={styles.wrap}>
       {label && <Text style={[styles.label, { color: theme.colors.text }]}>{label}</Text>}
@@ -23,8 +30,3 @@ export default function EVoidSlider({ value, onValueChange, min = 0, max = 1, st
     </View>
   );
 }
-const styles = StyleSheet.create({
-  wrap: { width: '100%', marginVertical: 8 },
-  label: { marginBottom: 4, fontWeight: '600' },
-  slider: { width: '100%' },
-});

--- a/components/ui/EVoidToast.tsx
+++ b/components/ui/EVoidToast.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 type Props = { message: string; type?: 'info' | 'danger' | 'success' };
 export default function EVoidToast({ message, type = 'info' }: Props) {
   const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
   const color = type === 'danger' ? theme.colors.danger : type === 'success' ? theme.colors.accent : theme.colors.primary;
+  const styles = StyleSheet.create({
+    toast: {
+      position: 'absolute',
+      bottom: spacing.xxxl,
+      left: spacing.xxl,
+      right: spacing.xxl,
+      borderRadius: spacing.md,
+      borderWidth: 2,
+      padding: spacing.lg,
+      alignItems: 'center',
+    },
+    text: { ...typography.toast },
+  });
   return (
-    <View style={[styles.toast, { borderColor: color }]}> 
+    <View style={[styles.toast, { borderColor: color, backgroundColor: theme.colors.surface + 'EE' }]}>
       <Text style={[styles.text, { color }]}>{message}</Text>
     </View>
   );
 }
-const styles = StyleSheet.create({
-  toast: { position: 'absolute', bottom: 32, left: 24, right: 24, backgroundColor: '#222E', borderRadius: 12, borderWidth: 2, padding: 16, alignItems: 'center' },
-  text: { fontWeight: '700', fontSize: 15 },
-});

--- a/components/ui/EVoidToggle.tsx
+++ b/components/ui/EVoidToggle.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { Switch, View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 type Props = { value: boolean; onValueChange: (v: boolean) => void; label?: string };
 export default function EVoidToggle({ value, onValueChange, label }: Props) {
   const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    row: { flexDirection: 'row', alignItems: 'center', marginVertical: spacing.sm },
+    label: { ...typography.label, marginRight: spacing.md },
+  });
   return (
     <View style={styles.row}>
       {label && <Text style={[styles.label, { color: theme.colors.text }]}>{label}</Text>}
@@ -17,7 +23,3 @@ export default function EVoidToggle({ value, onValueChange, label }: Props) {
     </View>
   );
 }
-const styles = StyleSheet.create({
-  row: { flexDirection: 'row', alignItems: 'center', marginVertical: 8 },
-  label: { marginRight: 12, fontWeight: '600' },
-});

--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -2,9 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
 import SessionStore from '../services/sessions/SessionStore';
 import SessionItem from '../components/logbook/SessionItem';
+import { useTheme } from '../theme';
+import { useDesignSystem } from '../theme/designSystem';
 
 export default function Logbook({ navigation }: any) {
   const [sessions, setSessions] = useState<any[]>([]);
+  const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
   useEffect(() => {
     (async () => {
       const list = await SessionStore.list();
@@ -12,6 +16,11 @@ export default function Logbook({ navigation }: any) {
     })();
   }, []);
 
+  const styles = StyleSheet.create({
+    flex: { flex: 1, backgroundColor: theme.colors.bg },
+    title: { ...typography.h1, color: theme.colors.text, margin: spacing.lg },
+    empty: { color: theme.colors.text + '88', textAlign: 'center', marginTop: spacing.xxxl },
+  });
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>Logbook</Text>
@@ -29,9 +38,3 @@ export default function Logbook({ navigation }: any) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  flex: { flex: 1, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', margin: 16 },
-  empty: { color: '#888', textAlign: 'center', marginTop: 40 },
-});

--- a/screens/Onboarding/HowTo.tsx
+++ b/screens/Onboarding/HowTo.tsx
@@ -1,25 +1,28 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 export default function OnboardingHowTo({ navigation }: any) {
+  const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.xxl, backgroundColor: theme.colors.bg },
+    title: { ...typography.h1, color: theme.colors.text, marginBottom: spacing.xxl },
+    body: { color: theme.colors.text + 'CC', ...typography.body, textAlign: 'center', marginBottom: spacing.xxl },
+    btn: { minWidth: 160 },
+  });
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>How to Use Ech0Void</Text>
       <Text style={styles.body}>
-        1. Begin a Live ITC session to record and mark anomalies.\n
-        2. Review your sessions in the Logbook.\n
-        3. Export, share, or analyze your results.\n
+        1. Begin a Live ITC session to record and mark anomalies.{"\n"}
+        2. Review your sessions in the Logbook.{"\n"}
+        3. Export, share, or analyze your results.{"\n"}
         4. Explore advanced features in Settings.
       </Text>
       <EVoidButton label="Privacy & Permissions" onPress={() => navigation?.navigate?.('OnboardingPrivacy')} style={styles.btn} />
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
-  btn: { minWidth: 160 },
-});

--- a/screens/Onboarding/Intro.tsx
+++ b/screens/Onboarding/Intro.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 export default function OnboardingIntro({ navigation }: any) {
+  const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.xxl, backgroundColor: theme.colors.bg },
+    title: { ...typography.h1, color: theme.colors.text, marginBottom: spacing.xxl },
+    body: { color: theme.colors.text + 'CC', ...typography.body, textAlign: 'center', marginBottom: spacing.xxl },
+    btn: { minWidth: 160 },
+  });
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>Welcome to Ech0Void</Text>
       <Text style={styles.body}>
-        Ech0Void is a modern ITC toolkit for exploring anomalous audio, spirit communication, and creative consciousness. 
-        Record, analyze, and share your sessions with a beautiful, intuitive interface.
+        Ech0Void is a modern ITC toolkit for exploring anomalous audio, spirit communication, and creative consciousness. Record, analyze, and share your sessions with a beautiful, intuitive interface.
       </Text>
       <EVoidButton label="How to Use" onPress={() => navigation?.navigate?.('OnboardingHowTo')} style={styles.btn} />
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
-  btn: { minWidth: 160 },
-});

--- a/screens/Onboarding/Privacy.tsx
+++ b/screens/Onboarding/Privacy.tsx
@@ -2,8 +2,18 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useTheme } from '../../theme';
+import { useDesignSystem } from '../../theme/designSystem';
 
 export default function OnboardingPrivacy({ navigation }: any) {
+  const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.xxl, backgroundColor: theme.colors.bg },
+    title: { ...typography.h1, color: theme.colors.text, marginBottom: spacing.xxl },
+    body: { color: theme.colors.text + 'CC', ...typography.body, textAlign: 'center', marginBottom: spacing.xxl },
+    btn: { minWidth: 160 },
+  });
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>Privacy & Permissions</Text>
@@ -12,21 +22,22 @@ export default function OnboardingPrivacy({ navigation }: any) {
         Your data is stored locally and never shared without your consent.{"\n"}
         You can export or delete your sessions at any time from the Logbook.
       </Text>
-      <EVoidButton label="Get Started" onPress={async () => {
-        await AsyncStorage.setItem('onboarded', '1');
-        navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
-      }} style={styles.btn} />
-      <EVoidButton label="Skip Onboarding" onPress={async () => {
-        await AsyncStorage.setItem('onboarded', '1');
-        navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
-      }} style={[styles.btn, { marginTop: 16, backgroundColor: '#333' }]} />
+      <EVoidButton
+        label="Get Started"
+        onPress={async () => {
+          await AsyncStorage.setItem('onboarded', '1');
+          navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
+        }}
+        style={styles.btn}
+      />
+      <EVoidButton
+        label="Skip Onboarding"
+        onPress={async () => {
+          await AsyncStorage.setItem('onboarded', '1');
+          navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
+        }}
+        style={[styles.btn, { marginTop: spacing.lg, backgroundColor: theme.colors.surface }]}
+      />
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
-  btn: { minWidth: 160 },
-});

--- a/screens/Settings.tsx
+++ b/screens/Settings.tsx
@@ -2,27 +2,28 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme, themes, ThemeName } from '../theme';
 import Chip from '../components/controls/Chip';
+import { useDesignSystem } from '../theme/designSystem';
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
+  const styles = StyleSheet.create({
+    flex: { flex: 1, padding: spacing.xxl, backgroundColor: theme.colors.bg },
+    title: { ...typography.h1, color: theme.colors.text, marginBottom: spacing.xxl },
+    label: { ...typography.label, color: theme.colors.text, marginTop: spacing.xl },
+  });
   return (
-    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
-      <Text style={[styles.title, { color: theme.colors.text }]}>Settings</Text>
-      <Text style={[styles.label, { color: theme.colors.text }]}>Theme</Text>
+    <View style={styles.flex}>
+      <Text style={styles.title}>Settings</Text>
+      <Text style={styles.label}>Theme</Text>
       <Chip
         options={Object.keys(themes) as ThemeName[]}
         value={theme.name}
-  onChange={v => setTheme(v as ThemeName)}
+        onChange={v => setTheme(v as ThemeName)}
       />
-      <Text style={[styles.label, { color: theme.colors.text }]}>Audio FX (coming soon)</Text>
-      <Text style={[styles.label, { color: theme.colors.text }]}>Performance (coming soon)</Text>
-      <Text style={[styles.label, { color: theme.colors.text }]}>Privacy (coming soon)</Text>
+      <Text style={styles.label}>Audio FX (coming soon)</Text>
+      <Text style={styles.label}>Performance (coming soon)</Text>
+      <Text style={styles.label}>Privacy (coming soon)</Text>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  flex: { flex: 1, padding: 24 },
-  title: { fontSize: 28, fontWeight: '800', marginBottom: 24 },
-  label: { fontSize: 16, fontWeight: '600', marginTop: 18 },
-});

--- a/screens/SigilMaker.tsx
+++ b/screens/SigilMaker.tsx
@@ -2,21 +2,32 @@ import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 import buildSigil from '../services/sigil/buildSigil';
+import { useTheme } from '../theme';
+import { useDesignSystem } from '../theme/designSystem';
 
 export default function SigilMaker() {
   const [phrase, setPhrase] = useState('');
   const [sigilPath, setSigilPath] = useState('');
+  const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
 
   const handleGenerate = () => {
     setSigilPath(buildSigil(phrase));
   };
 
+  const styles = StyleSheet.create({
+    container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.lg, backgroundColor: theme.colors.bg },
+    title: { ...typography.title, color: theme.colors.text, marginBottom: spacing.lg },
+    input: { borderWidth: 1, borderColor: theme.colors.surface, padding: spacing.sm, width: '100%', marginBottom: spacing.lg, color: theme.colors.text },
+    button: { ...typography.button, color: theme.colors.primary, marginBottom: spacing.lg },
+  });
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Sigil Maker</Text>
       <TextInput
         style={styles.input}
         placeholder="Enter a phrase"
+        placeholderTextColor={theme.colors.text}
         value={phrase}
         onChangeText={setPhrase}
       />
@@ -25,16 +36,10 @@ export default function SigilMaker() {
       </TouchableOpacity>
       {sigilPath ? (
         <Svg height="100" width="100" viewBox="0 0 100 100">
-          <Path d={sigilPath} stroke="black" fill="none" />
+          <Path d={sigilPath} stroke={theme.colors.text} fill="none" />
         </Svg>
       ) : null}
     </View>
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
-  title: { fontSize: 24, marginBottom: 16 },
-  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, width: '100%', marginBottom: 16 },
-  button: { color: 'blue', marginBottom: 16 },
-});

--- a/screens/SpiritBoard.tsx
+++ b/screens/SpiritBoard.tsx
@@ -2,6 +2,8 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import getEntropy from '../services/rng/Entropy';
+import { useTheme } from '../theme';
+import { useDesignSystem } from '../theme/designSystem';
 
 const LETTERS = [
   ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
@@ -12,6 +14,8 @@ const LETTERS = [
 
 export default function SpiritBoard() {
   const [pointer, setPointer] = useState({ row: 1, col: 3 });
+  const { theme } = useTheme();
+  const { spacing, typography } = useDesignSystem();
 
   // Use entropy from sensors for pointer movement
   useEffect(() => {
@@ -29,6 +33,24 @@ export default function SpiritBoard() {
     return () => clearInterval(interval);
   }, []);
 
+  const styles = StyleSheet.create({
+    flex: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: theme.colors.bg },
+    title: { ...typography.h1, color: theme.colors.text, marginBottom: spacing.xxl },
+    grid: { marginBottom: spacing.xxxl },
+    row: { flexDirection: 'row' },
+    cell: {
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      backgroundColor: theme.colors.surface,
+      margin: spacing.sm,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    pointer: { backgroundColor: theme.colors.accent, borderWidth: 2, borderColor: theme.colors.text },
+    letter: { color: theme.colors.text, fontSize: 22, fontWeight: '700' },
+    tip: { color: theme.colors.text + '99', fontSize: 13, marginTop: spacing.md },
+  });
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>Spirit Board</Text>
@@ -50,14 +72,3 @@ export default function SpiritBoard() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  grid: { marginBottom: 32 },
-  row: { flexDirection: 'row' },
-  cell: { width: 44, height: 44, borderRadius: 22, backgroundColor: '#222', margin: 6, alignItems: 'center', justifyContent: 'center' },
-  pointer: { backgroundColor: '#00E0FF', borderWidth: 2, borderColor: '#fff' },
-  letter: { color: '#fff', fontSize: 22, fontWeight: '700' },
-  tip: { color: '#aaa', fontSize: 13, marginTop: 12 },
-});

--- a/theme/designSystem.ts
+++ b/theme/designSystem.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+
+export const spacing = {
+  none: 0,
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 20,
+  xxl: 24,
+  xxxl: 32,
+};
+
+export const typography = {
+  h1: { fontSize: 28, fontWeight: '800' as const },
+  h2: { fontSize: 24, fontWeight: '800' as const },
+  title: { fontSize: 18, fontWeight: '700' as const },
+  body: { fontSize: 16, fontWeight: '400' as const },
+  caption: { fontSize: 13, fontWeight: '400' as const },
+  button: { fontSize: 16, fontWeight: '700' as const, letterSpacing: 0.4 },
+  chip: { fontSize: 14, fontWeight: '600' as const },
+  label: { fontSize: 16, fontWeight: '600' as const },
+  toast: { fontSize: 15, fontWeight: '700' as const },
+};
+
+export const elevation = {
+  none: { shadowOpacity: 0, shadowRadius: 0, shadowOffset: { width: 0, height: 0 } },
+  low: { shadowOpacity: 0.15, shadowRadius: 8, shadowOffset: { width: 0, height: 2 } },
+  medium: { shadowOpacity: 0.3, shadowRadius: 12, shadowOffset: { width: 0, height: 4 } },
+};
+
+export function useDesignSystem() {
+  return useMemo(() => ({ spacing, typography, elevation }), []);
+}
+
+export type DesignSystem = ReturnType<typeof useDesignSystem>;

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, PropsWithChildren } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-export type ThemeName = 'Void' | 'NeonFlux' | 'Astral';
+export type ThemeName = 'Void' | 'NeonFlux' | 'Astral' | 'Lumen' | 'HighContrast';
 
 export interface Theme {
   name: ThemeName;
@@ -44,6 +44,36 @@ export const themes: Record<ThemeName, Theme> = {
     name: 'Astral',
     colors: {
       bg: '#0C0A12', surface: '#151224', primary: '#8AE6FF', accent: '#E6C3FF', text: '#F2F5FF', danger: '#FF4D6D',
+    },
+    spacing: [0, 4, 8, 16, 24, 32],
+    radii: [0, 6, 12, 20],
+    shadow: '0 2px 8px #0008',
+    opacity: { disabled: 0.4, overlay: 0.12 },
+  },
+  Lumen: {
+    name: 'Lumen',
+    colors: {
+      bg: '#FFFFFF',
+      surface: '#F2F2F2',
+      primary: '#007AFF',
+      accent: '#FF2D55',
+      text: '#000000',
+      danger: '#FF3B30',
+    },
+    spacing: [0, 4, 8, 16, 24, 32],
+    radii: [0, 6, 12, 20],
+    shadow: '0 2px 8px #0008',
+    opacity: { disabled: 0.4, overlay: 0.12 },
+  },
+  HighContrast: {
+    name: 'HighContrast',
+    colors: {
+      bg: '#000000',
+      surface: '#000000',
+      primary: '#FFFFFF',
+      accent: '#FFFF00',
+      text: '#FFFFFF',
+      danger: '#FF0000',
     },
     spacing: [0, 4, 8, 16, 24, 32],
     radii: [0, 6, 12, 20],


### PR DESCRIPTION
## Summary
- introduce reusable design system tokens and hook
- refactor UI components and screens to consume design tokens and theme colors
- add light and high contrast themes and expose theme selection in settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aebf73d9d4832e8c2719875fd88276