### PR TITLE
Revamp logbook session cards

### DIFF
--- a/components/logbook/SessionItem.tsx
+++ b/components/logbook/SessionItem.tsx
@@ -1,25 +1,97 @@
 import React from 'react';
-import { View, Text, StyleSheet, Pressable } from 'react-native';
-// TODO: Show session summary, type, date, and quick actions
-export default function SessionItem({ session, onDelete, onView }: { session: any; onDelete: () => void; onView: () => void }) {
+import { View, Text, StyleSheet, Image, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+type SessionItemProps = {
+  session: any;
+  onDelete?: () => void;
+  onView?: () => void;
+};
+
+// Card-style representation of a logbook session
+export default function SessionItem({ session, onDelete, onView }: SessionItemProps) {
+  const handleView = () => {
+    onView && onView();
+  };
+
+  const handleDelete = () => {
+    onDelete && onDelete();
+  };
+
   return (
-    <View style={styles.item}>
-      <Text style={styles.type}>{session.type || 'Session'}</Text>
-      <Text style={styles.date}>{new Date(session.created).toLocaleString()}</Text>
-      <Text style={styles.info}>Anomalies: {session.anomalies?.length ?? 0}</Text>
+    <View style={styles.card}>
+      <Pressable onPress={handleView} style={styles.preview}>
+        {session.snapshot ? (
+          <Image source={{ uri: session.snapshot }} style={styles.thumbnail} />
+        ) : (
+          <View style={[styles.thumbnail, styles.placeholder]} />
+        )}
+      </Pressable>
+      <View style={styles.meta}>
+        <Text style={styles.type}>{session.type || 'Session'}</Text>
+        <Text style={styles.date}>{new Date(session.date || session.created).toLocaleString()}</Text>
+        <Text style={styles.info}>Anomalies: {session.anomalies?.length ?? 0}</Text>
+      </View>
       <View style={styles.actions}>
-        <Pressable onPress={onView} style={styles.actionButton}><Text style={styles.actionText}>View</Text></Pressable>
-        <Pressable onPress={onDelete} style={styles.actionButton}><Text style={styles.actionText}>Delete</Text></Pressable>
+        <Pressable onPress={handleView} style={styles.iconButton} accessibilityLabel="View session">
+          <Ionicons name="eye" size={20} color="#fff" />
+        </Pressable>
+        <Pressable onPress={handleDelete} style={styles.iconButton} accessibilityLabel="Delete session">
+          <Ionicons name="trash" size={20} color="#ff6666" />
+        </Pressable>
       </View>
     </View>
   );
 }
+
 const styles = StyleSheet.create({
-  item: { padding: 16, borderRadius: 12, backgroundColor: '#222', marginVertical: 6 },
-  type: { color: '#fff', fontWeight: '700', fontSize: 16 },
-  date: { color: '#aaa', fontSize: 13, marginTop: 2 },
-  info: { color: '#8ff', fontSize: 13, marginTop: 4 },
-  actions: { flexDirection: 'row', marginTop: 8 },
-  actionButton: { marginRight: 12, padding: 8, backgroundColor: '#444', borderRadius: 8 },
-  actionText: { color: '#fff', fontSize: 13 },
+  card: {
+    backgroundColor: '#1e1e1e',
+    borderRadius: 12,
+    overflow: 'hidden',
+    margin: 8,
+    flex: 1,
+  },
+  preview: {
+    width: '100%',
+    aspectRatio: 16 / 9,
+  },
+  thumbnail: {
+    width: '100%',
+    height: '100%',
+  },
+  placeholder: {
+    backgroundColor: '#333',
+  },
+  meta: {
+    padding: 12,
+  },
+  type: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  date: {
+    color: '#aaa',
+    fontSize: 13,
+    marginTop: 2,
+  },
+  info: {
+    color: '#8ff',
+    fontSize: 13,
+    marginTop: 4,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: 8,
+    paddingBottom: 8,
+    gap: 8,
+  },
+  iconButton: {
+    padding: 6,
+    backgroundColor: '#2a2a2a',
+    borderRadius: 8,
+  },
 });
+

--- a/docs/ui-logbook.md
+++ b/docs/ui-logbook.md
@@ -1,0 +1,27 @@
+# Logbook UI Guidelines
+
+The logbook uses a card grid layout to present each session consistently across
+the application. When contributing UI related changes, keep the following
+guidelines in mind:
+
+## Card Layout
+- Cards occupy roughly half of the available width with equal margins.
+- Use a dark background (`#1e1e1e`) and rounded corners (`12px`).
+- The top of the card displays an optional snapshot image using a 16:9 aspect
+  ratio. If no image is available, render a neutral placeholder.
+
+## Metadata
+- Session type is the primary label and should be bold and white.
+- Dates use the device locale and appear just below the type in a muted gray
+  tone.
+- Display the anomaly count with a cyan accent for quick scanning.
+
+## Actions
+- Action icons (currently eye and trash from `Ionicons`) sit in the bottom
+  right corner of each card.
+- Wrap icons in touch targets with a subtle dark background (`#2a2a2a`) and
+  an 8px border radius.
+
+These guidelines ensure new session types or additional controls maintain a
+cohesive appearance within the logbook.
+

--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -1,29 +1,73 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import { View, Text, SectionList, StyleSheet } from 'react-native';
 import SessionStore from '../services/sessions/SessionStore';
 import SessionItem from '../components/logbook/SessionItem';
 
+type Section = { title: string; data: any[][] };
+
+// Group sessions by month and chunk into rows for a grid layout
+const groupSessions = (sessions: any[]): Section[] => {
+  const groups: Record<string, any[]> = {};
+  sessions.forEach(session => {
+    const date = new Date(session.date || session.created);
+    const title = date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+    if (!groups[title]) groups[title] = [];
+    groups[title].push(session);
+  });
+
+  const chunk = (arr: any[], size: number) =>
+    arr.reduce((acc: any[][], _, i) => {
+      if (i % size === 0) acc.push(arr.slice(i, i + size));
+      return acc;
+    }, []);
+
+  return Object.keys(groups).map(title => ({
+    title,
+    data: chunk(groups[title], 2),
+  }));
+};
+
 export default function Logbook({ navigation }: any) {
-  const [sessions, setSessions] = useState<any[]>([]);
-  useEffect(() => {
-    (async () => {
-      const list = await SessionStore.list();
-      setSessions(list.reverse());
-    })();
+  const [sections, setSections] = useState<Section[]>([]);
+
+  const load = useCallback(async () => {
+    const list = await SessionStore.list();
+    setSections(groupSessions(list.reverse()));
   }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleView = (session: any) => {
+    navigation?.navigate?.('SessionDetail', { session });
+  };
+
+  const handleDelete = async (id: string) => {
+    await SessionStore.delete(id);
+    load();
+  };
 
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>Logbook</Text>
-      <FlatList
-        data={sessions}
-        keyExtractor={item => item.id}
+      <SectionList
+        sections={sections}
+        keyExtractor={(item, index) => item.map((s: any) => s.id).join('-') + index}
         renderItem={({ item }) => (
-          <TouchableOpacity onPress={() => navigation?.navigate?.('SessionDetail', { session: item })}>
-            <SessionItem session={item} />
-          </TouchableOpacity>
+          <View style={styles.row}>
+            {item.map((session: any) => (
+              <SessionItem
+                key={session.id}
+                session={session}
+                onView={() => handleView(session)}
+                onDelete={() => handleDelete(session.id)}
+              />
+            ))}
+          </View>
         )}
-        contentContainerStyle={{ padding: 16 }}
+        renderSectionHeader={({ section: { title } }) => <Text style={styles.section}>{title}</Text>}
+        contentContainerStyle={styles.list}
         ListEmptyComponent={<Text style={styles.empty}>No sessions yet.</Text>}
       />
     </View>
@@ -33,5 +77,9 @@ export default function Logbook({ navigation }: any) {
 const styles = StyleSheet.create({
   flex: { flex: 1, backgroundColor: '#111' },
   title: { fontSize: 28, fontWeight: '800', color: '#fff', margin: 16 },
+  section: { color: '#ccc', fontSize: 18, marginHorizontal: 16, marginTop: 16 },
+  row: { flexDirection: 'row' },
+  list: { paddingHorizontal: 8 },
   empty: { color: '#888', textAlign: 'center', marginTop: 40 },
 });
+

--- a/services/sessions/SessionStore.ts
+++ b/services/sessions/SessionStore.ts
@@ -11,12 +11,27 @@ const MEDIA_DIR = `${FileSystem.documentDirectory}media/`;
 async function create(session: any) {
   try {
     const sessions = await list();
+    const mediaPath = `${MEDIA_DIR}${session.id}/`;
     sessions.push(session);
     await AsyncStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
 
-    if (session.media) {
-      const mediaPath = `${MEDIA_DIR}${session.id}/`;
+    if (session.snapshot || session.media) {
       await FileSystem.makeDirectoryAsync(mediaPath, { intermediates: true });
+    }
+
+    if (session.snapshot) {
+      try {
+        const name = session.snapshot.split('/').pop();
+        const dest = `${mediaPath}${name}`;
+        await FileSystem.copyAsync({ from: session.snapshot, to: dest });
+        session.snapshot = dest;
+        await AsyncStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
+      } catch (fileError) {
+        console.error('Failed to save snapshot:', fileError);
+      }
+    }
+
+    if (session.media) {
       for (const file of session.media) {
         try {
           await FileSystem.copyAsync({ from: file, to: `${mediaPath}${file.split('/').pop()}` });
@@ -56,6 +71,18 @@ async function update(id: string, data: any) {
     const sessions = await list();
     const idx = sessions.findIndex((s: any) => s.id === id);
     if (idx !== -1) {
+      const mediaPath = `${MEDIA_DIR}${id}/`;
+      if (data.snapshot) {
+        try {
+          await FileSystem.makeDirectoryAsync(mediaPath, { intermediates: true });
+          const name = data.snapshot.split('/').pop();
+          const dest = `${mediaPath}${name}`;
+          await FileSystem.copyAsync({ from: data.snapshot, to: dest });
+          data.snapshot = dest;
+        } catch (fileError) {
+          console.error('Failed to save snapshot:', fileError);
+        }
+      }
       sessions[idx] = { ...sessions[idx], ...data };
       await AsyncStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
       return true;


### PR DESCRIPTION
## Summary
- display sessions as cards with optional thumbnails and action icons
- show logbook in a sectioned grid powered by SessionItem cards
- persist optional session snapshot images and document logbook styling guidelines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aebf94dbe0832ea87b85c5d63ad69d