### PR TITLE
test: add sigil builder tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "android": "expo start --dev-client",
     "web": "expo start --web",
     "devclient": "expo start --dev-client --tunnel",
-    "test": "node --test --import tsx tests/signal.test.ts"
+    "test": "node --test --import tsx tests/signal.test.ts tests/buildSigil.test.ts"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.1.2",

--- a/tests/buildSigil.test.ts
+++ b/tests/buildSigil.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import buildSigil from '../services/sigil/buildSigil.ts';
+
+test('buildSigil generates path for basic phrase', () => {
+  const path = buildSigil('abc');
+  assert.strictEqual(path, 'M90,50L10,50.00000000000001Z');
+});
+
+test('buildSigil removes vowels and duplicate letters', () => {
+  const path = buildSigil('Aeaaebbc');
+  assert.strictEqual(path, 'M90,50L10,50.00000000000001Z');
+});


### PR DESCRIPTION
## Summary
- add tests for sigil builder ensuring SVG path generation and input sanitization
- run sigil tests alongside existing signal tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec2e8e580832eb3672b876c9e203b