### PR TITLE
Add reanimated navigation transitions and UI animations

### DIFF
--- a/components/ui/EVoidButton.tsx
+++ b/components/ui/EVoidButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useTheme } from '../../theme';
 
 type Props = {
@@ -11,14 +12,24 @@ type Props = {
   disabled?: boolean;
 };
 
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
 export default function EVoidButton({ label, onPress, variant = 'solid', style, testID, disabled = false }: Props) {
   const { theme } = useTheme();
+  const scale = useSharedValue(1);
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
   return (
-    <Pressable
+    <AnimatedPressable
       testID={testID}
       accessibilityRole="button"
       hitSlop={12}
       onPress={disabled ? undefined : onPress}
+      onPressIn={() => (scale.value = withTiming(0.96, { duration: 100 }))}
+      onPressOut={() => (scale.value = withTiming(1, { duration: 100 }))}
+      onHoverIn={() => (scale.value = withTiming(1.04, { duration: 150 }))}
+      onHoverOut={() => (scale.value = withTiming(1, { duration: 150 }))}
       style={({ pressed }) => [
         styles.btn,
         variant === 'outline' && { backgroundColor: 'transparent', borderColor: theme.colors.accent, borderWidth: 2 },
@@ -27,12 +38,13 @@ export default function EVoidButton({ label, onPress, variant = 'solid', style, 
         pressed && !disabled && { opacity: 0.8 },
         disabled && { opacity: 0.5 },
         style,
+        animatedStyle,
       ]}
       pointerEvents={disabled ? 'none' : 'auto'}
       accessibilityState={{ disabled }}
     >
       <Text style={[styles.text, { color: theme.colors.text }]}>{label}</Text>
-    </Pressable>
+    </AnimatedPressable>
   );
 }
 const styles = StyleSheet.create({

--- a/components/ui/EVoidToggle.tsx
+++ b/components/ui/EVoidToggle.tsx
@@ -1,19 +1,38 @@
 import React from 'react';
-import { Switch, View, Text, StyleSheet } from 'react-native';
+import { Switch, View, Text, StyleSheet, Pressable } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useTheme } from '../../theme';
 
 type Props = { value: boolean; onValueChange: (v: boolean) => void; label?: string };
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
 export default function EVoidToggle({ value, onValueChange, label }: Props) {
   const { theme } = useTheme();
+  const scale = useSharedValue(1);
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
   return (
     <View style={styles.row}>
       {label && <Text style={[styles.label, { color: theme.colors.text }]}>{label}</Text>}
-      <Switch
-        value={value}
-        onValueChange={onValueChange}
-        trackColor={{ true: theme.colors.accent, false: theme.colors.surface }}
-        thumbColor={value ? theme.colors.primary : theme.colors.surface}
-      />
+      <AnimatedPressable
+        onPress={() => onValueChange(!value)}
+        onPressIn={() => (scale.value = withTiming(0.95, { duration: 100 }))}
+        onPressOut={() => (scale.value = withTiming(1, { duration: 100 }))}
+        onHoverIn={() => (scale.value = withTiming(1.05, { duration: 150 }))}
+        onHoverOut={() => (scale.value = withTiming(1, { duration: 150 }))}
+        accessibilityRole="switch"
+        accessibilityState={{ checked: value }}
+      >
+        <Animated.View style={animatedStyle}>
+          <Switch
+            pointerEvents="none"
+            value={value}
+            trackColor={{ true: theme.colors.accent, false: theme.colors.surface }}
+            thumbColor={value ? theme.colors.primary : theme.colors.surface}
+          />
+        </Animated.View>
+      </AnimatedPressable>
     </View>
   );
 }

--- a/docs/animation.md
+++ b/docs/animation.md
@@ -1,0 +1,19 @@
+# Animation Guidelines
+
+This project uses [react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/) for subtle motion and navigation effects.
+
+## Stack Transitions
+- Custom fade transitions are defined in `src/navigation/AppNavigator.tsx`.
+- Adjust `fadeConfig` and the `forFade` interpolator to tweak timing or style.
+
+## Component Interactions
+- `EVoidButton` and `EVoidToggle` scale slightly on press and hover.
+- Keep interaction animations under 200ms to preserve responsiveness.
+
+## Screen Transitions
+- Screens such as `HomeScreen` and `TransmissionScreen` use `entering`/`exiting` props for page-level fades or slides.
+- Wrap the root layout in an `Animated` component and choose an appropriate preset (`FadeIn`, `FadeOut`, etc.).
+
+## Best Practices
+- Prefer `withTiming` for simple transitions; `withSpring` for elastic effects.
+- Favor subtle motion to maintain the app's atmosphere and performance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-community/slider": "4.5.6",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.25",
+        "@react-navigation/stack": "^7.4.7",
         "expo": "~53.0.0",
         "expo-av": "~15.1.7",
         "expo-camera": "~16.1.11",
@@ -3632,6 +3633,24 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11"
+      }
+    },
+    "node_modules/@react-navigation/stack": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-7.4.7.tgz",
+      "integrity": "sha512-1VDxuou+iZXEK7o+ZtCIU3b+upAwLFolptEKX+GldUy78GR66hltPxmu8bJeb2ZcgUSowBTHw03kNY1gyOdW3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.6.3",
+        "color": "^4.2.3"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.17",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 2.0.0",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-native-community/slider": "4.5.6",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.25",
+    "@react-navigation/stack": "^7.4.7",
     "expo": "~53.0.0",
     "expo-av": "~15.1.7",
     "expo-camera": "~16.1.11",

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { navTheme } from '../theme/theme';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createStackNavigator, StackCardStyleInterpolator } from '@react-navigation/stack';
+import { Easing } from 'react-native-reanimated';
 
 import HomeScreen from '../screens/HomeScreen';
 import TransmissionScreen from '../screens/TransmissionScreen';
@@ -25,7 +26,21 @@ export type RootStackParamList = {
   SessionDetail: { session: any };
 };
 
-const Stack = createNativeStackNavigator<RootStackParamList>();
+const Stack = createStackNavigator<RootStackParamList>();
+
+const fadeConfig = {
+  animation: 'timing',
+  config: {
+    duration: 350,
+    easing: Easing.out(Easing.cubic),
+  },
+};
+
+const forFade: StackCardStyleInterpolator = ({ current }) => ({
+  cardStyle: {
+    opacity: current.progress,
+  },
+});
 
 function AppNavigator() {
   // Log navigation container state
@@ -36,7 +51,14 @@ function AppNavigator() {
       theme={navTheme}
       onStateChange={(state) => console.log('[AppNavigator] Navigation state changed:', state)}
     >
-      <Stack.Navigator initialRouteName="Welcome" screenOptions={{ headerShown: false }}>
+      <Stack.Navigator
+        initialRouteName="Welcome"
+        screenOptions={{
+          headerShown: false,
+          transitionSpec: { open: fadeConfig, close: fadeConfig },
+          cardStyleInterpolator: forFade,
+        }}
+      >
         <Stack.Screen name="Welcome" component={WelcomeScreen} />
         <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="Transmission" component={TransmissionScreen} />

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { View, Text, StyleSheet, StatusBar, Alert } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { StackScreenProps } from '@react-navigation/stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
 import UIButton from '../components/UIButton';
 import { colors } from '../theme/colors';
 import { hasNativeVoice, startListening } from '../voice/adapter';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
+type Props = StackScreenProps<RootStackParamList, 'Home'>;
 
 export default function HomeScreen({ navigation }: Props) {
   const onBegin = async () => {
@@ -28,10 +29,14 @@ export default function HomeScreen({ navigation }: Props) {
     }
   };
 
+  const AnimatedGradient = Animated.createAnimatedComponent(LinearGradient);
+
   return (
-    <LinearGradient
+    <AnimatedGradient
       colors={[colors.bg, '#0A0A1C', colors.card]}
       style={styles.flex}
+      entering={FadeIn.duration(300)}
+      exiting={FadeOut.duration(300)}
     >
       <StatusBar barStyle="light-content" />
       <View style={styles.container}>
@@ -45,7 +50,7 @@ export default function HomeScreen({ navigation }: Props) {
 
       {/* decorative neon ring that never intercepts touches */}
       <View pointerEvents="none" style={styles.ring} />
-    </LinearGradient>
+    </AnimatedGradient>
   );
 }
 

--- a/src/screens/TransmissionScreen.tsx
+++ b/src/screens/TransmissionScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import Animated, { FadeInRight, FadeOutLeft } from 'react-native-reanimated';
 import { colors } from '../theme/colors';
 
 // Added type annotation for navigation prop
@@ -8,13 +9,20 @@ const TransmissionScreen = ({ navigation }: { navigation: any }) => {
   // Log navigation prop
   console.log('[TransmissionScreen] navigation prop:', navigation);
 
+  const AnimatedGradient = Animated.createAnimatedComponent(LinearGradient);
+
   return (
-    <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
+    <AnimatedGradient
+      colors={[colors.bg, '#0A0A1C', colors.card]}
+      style={{ flex: 1 }}
+      entering={FadeInRight.duration(300)}
+      exiting={FadeOutLeft.duration(300)}
+    >
       <View style={styles.container}>
         <Text style={styles.h1}>Transmission</Text>
         <Text style={styles.p}>Listening / responses will appear here.</Text>
       </View>
-    </LinearGradient>
+    </AnimatedGradient>
   );
 };
 


### PR DESCRIPTION
## Summary
- swap to stack navigator with Reanimated fade transition
- add press/hover scale animations to EVoidButton and EVoidToggle
- animate page entrances/exits on Home and Transmission screens
- document animation guidelines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aebf7ec940832e96e083207f038a5a