### PR TITLE
feat: adjust engine via ambient sensor

### DIFF
--- a/src/core/audio/evpEngine.ts
+++ b/src/core/audio/evpEngine.ts
@@ -7,6 +7,8 @@ export type Engine = {
   settings:SweepSettings;
   setSettings:(p:Partial<SweepSettings>)=>void;
   level$:(cb:(n:number)=>void)=>()=>void; // subscribe to mock amplitude 0..1
+  /** update sweep settings based on ambient sensor reading */
+  applyAmbient:(lux:number)=>void;
 };
 export const PRESETS = {
   Focused:{ rateHz:4, dwellMs:120, range:[1000,3000] as [number,number] },
@@ -17,9 +19,16 @@ export function createEngine():Engine{
   let settings:SweepSettings = { rateHz:3.0, dwellMs:180, enabled:{PINK:true,WHITE:false,AM:true,FM:true,AETHER:true}, range:[300,8000], aether:{grain:0.2, mod:0.5} };
   const subs = new Set<(n:number)=>void>();
   const id = setInterval(()=>{ const amp = 0.2 + Math.random()*0.8; subs.forEach(s=>s(amp)); }, 100);
+  const setSettings = (p:Partial<SweepSettings>)=>{ settings = {...settings, ...p, range:p.range||settings.range, aether:{...settings.aether, ...(p.aether||{})} }; };
   return {
     get settings(){ return settings; },
-    setSettings(p){ settings = {...settings, ...p, range:p.range||settings.range, aether:{...settings.aether, ...(p.aether||{})} }; },
-    level$(cb){ subs.add(cb); return ()=>subs.delete(cb); }
+    setSettings,
+    level$(cb){ subs.add(cb); return ()=>subs.delete(cb); },
+    applyAmbient(lux:number){
+      const norm = Math.min(Math.max(lux,0),1000)/1000; // normalize 0..1
+      const rateHz = 2 + norm*6; // 2..8 Hz sweep rate
+      const range:[number,number] = [300, 3000 + norm*5000];
+      setSettings({ rateHz, range });
+    }
   };
 }

--- a/src/hooks/useAmbientLight.ts
+++ b/src/hooks/useAmbientLight.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import { LightSensor } from 'expo-sensors';
+
+/** Stream ambient light sensor readings in lux */
+export function useAmbientLight(interval:number = 1000){
+  const [lux,setLux] = useState(0);
+  useEffect(()=>{
+    LightSensor.setUpdateInterval(interval);
+    const sub = LightSensor.addListener((e:any)=>{
+      setLux(e.illuminance ?? 0);
+    });
+    return ()=>sub.remove();
+  },[interval]);
+  return lux;
+}

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -8,15 +8,18 @@ import Toggle from '../components/Toggle';
 import { speakEsmera } from '../core/audio/tts';
 import { useTranscription } from '../core/audio/transcription';
 import { detectAnomalies, setSensitivity } from '../core/anomaly/detector';
+import { useAmbientLight } from '../hooks/useAmbientLight';
 
 export default function SessionScreen({navigation}:any){
   const { engine, session, start, stop, sync } = useSession();
   const { text, conf, listening, supported, start:startASR, stop:stopASR } = useTranscription();
+  const ambient = useAmbientLight();
   const [amp,setAmp] = useState(0);
   const [mode,setMode] = useState<'Standard'|'Mana'|'Reverse'|'DreamLink'|'Shadow'|'CallAndResponse'>('Standard');
   const [hits,setHits] = useState<any[]>([]);
 
   useEffect(()=> engine.level$(setAmp), [engine]);
+  useEffect(()=>{ engine.applyAmbient(ambient); }, [ambient, engine]);
   useEffect(()=>{ const det = setInterval(()=>{
     const arr = detectAnomalies(new Float32Array(10));
     if(arr.length) setHits(h=>[...h,...arr]);


### PR DESCRIPTION
## Summary
- allow evp engine to adapt sweep rate and range from ambient light data
- add `useAmbientLight` hook powered by expo-sensors
- feed sensor values into Session screen to keep engine settings updated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec9f11114832e919bde09685a86ee