### PR TITLE
Add spectral waterfall visualization with FFT and indexed anomalies

### DIFF
--- a/src/components/SpectralWaterfall.tsx
+++ b/src/components/SpectralWaterfall.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export type SpectralWaterfallProps = {
+  data: number[][];
+  height?: number;
+};
+
+// Renders a simple waterfall view where each row represents an FFT slice
+// and each column a frequency bin. The value should be normalized [0,1].
+export default function SpectralWaterfall({ data, height = 120 }: SpectralWaterfallProps) {
+  const rows = data.slice(-Math.max(1, Math.floor(height)));
+  const rowHeight = rows.length ? height / rows.length : 0;
+  return (
+    <View style={{ width: '100%', height, overflow: 'hidden' }}>
+      {rows.map((row, i) => (
+        <View key={i} style={{ flexDirection: 'row', height: rowHeight }}>
+          {row.map((v, j) => (
+            <View
+              key={j}
+              style={{ flex: 1, backgroundColor: `rgba(0,217,255,${Math.min(1, Math.max(0, v))})` }}
+            />
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/src/core/anomaly/detector.ts
+++ b/src/core/anomaly/detector.ts
@@ -1,10 +1,18 @@
-// Simple mock anomaly detector; replace with real ML model later
+// Simple threshold based anomaly detector. Any sample whose absolute value
+// exceeds the current sensitivity is considered an anomaly. Each hit is
+// tagged with its time index (in samples) and a synthetic frequency value.
 export type AnomalyHit = { time:number; freq:number; confidence:number; uncertain?:boolean };
-export function detectAnomalies(_buffer:Float32Array):AnomalyHit[]{
-  if(Math.random() < 0.1){
-    return [{ time: Date.now(), freq: 1000+Math.random()*5000, confidence: Math.random(), uncertain: Math.random() < 0.5 }];
+
+export function detectAnomalies(buffer:Float32Array, sampleRate = 1):AnomalyHit[]{
+  const hits: AnomalyHit[] = [];
+  for(let i=0;i<buffer.length;i++){
+    const amp = Math.abs(buffer[i]);
+    if(amp >= sensitivity){
+      hits.push({ time: i / sampleRate, freq: i + 1, confidence: amp });
+    }
   }
-  return [];
+  return hits;
 }
+
 export let sensitivity = 0.5;
 export function setSensitivity(s:number){ sensitivity = s; }

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -5,9 +5,11 @@ import { colors } from '../theme/colors';
 import Meter from '../components/Meter';
 import Visualizer from '../components/Visualizer';
 import Toggle from '../components/Toggle';
+import SpectralWaterfall from '../components/SpectralWaterfall';
 import { speakEsmera } from '../core/audio/tts';
 import { useTranscription } from '../core/audio/transcription';
 import { detectAnomalies, setSensitivity } from '../core/anomaly/detector';
+import { fft } from '../utils/signal';
 
 export default function SessionScreen({navigation}:any){
   const { engine, session, start, stop, sync } = useSession();
@@ -15,12 +17,19 @@ export default function SessionScreen({navigation}:any){
   const [amp,setAmp] = useState(0);
   const [mode,setMode] = useState<'Standard'|'Mana'|'Reverse'|'DreamLink'|'Shadow'|'CallAndResponse'>('Standard');
   const [hits,setHits] = useState<any[]>([]);
+  const [spectra,setSpectra] = useState<number[][]>([]);
 
   useEffect(()=> engine.level$(setAmp), [engine]);
   useEffect(()=>{ const det = setInterval(()=>{
     const arr = detectAnomalies(new Float32Array(10));
     if(arr.length) setHits(h=>[...h,...arr]);
   },1000); return ()=>clearInterval(det); },[]);
+
+  useEffect(()=>{ const id = setInterval(()=>{
+    const samples = Float32Array.from({length:64},()=>Math.random()*2-1);
+    const bins = fft(samples);
+    setSpectra(s=>[...s.slice(-50), bins]);
+  },250); return ()=>clearInterval(id); },[]);
 
   const onSpeak = ()=> speakEsmera(text || 'Welcome to EchoVoid.', !text);
 
@@ -36,6 +45,7 @@ export default function SessionScreen({navigation}:any){
   <Text style={{color:colors.text, fontSize:18}}>Sweep / Meter</Text>
       <Visualizer level={amp}/>
     <Meter level={amp} color={colors.neon}/>
+  <SpectralWaterfall data={spectra} />
 
   <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Transcript</Text>
   <Text style={{color:colors.neon}}>{text || '…listening…'}</Text>

--- a/src/utils/signal.ts
+++ b/src/utils/signal.ts
@@ -1,2 +1,19 @@
 export function clamp(n:number,min=0,max=1){ return Math.min(max,Math.max(min,n)); }
 export function ema(prev:number, next:number, a=0.2){ return prev*(1-a)+next*a; }
+
+// Compute a simple discrete Fourier transform and return normalized magnitudes
+// of the positive frequency bins. Result length is N/2 for input length N.
+export function fft(buffer: Float32Array): number[] {
+  const N = buffer.length;
+  const out: number[] = new Array(Math.floor(N / 2)).fill(0);
+  for (let k = 0; k < out.length; k++) {
+    let re = 0, im = 0;
+    for (let n = 0; n < N; n++) {
+      const phi = (-2 * Math.PI * k * n) / N;
+      re += buffer[n] * Math.cos(phi);
+      im += buffer[n] * Math.sin(phi);
+    }
+    out[k] = Math.sqrt(re * re + im * im) / N;
+  }
+  return out;
+}

--- a/tests/detector.test.ts
+++ b/tests/detector.test.ts
@@ -1,11 +1,12 @@
 import { detectAnomalies } from '../src/core/anomaly/detector';
 
 describe('Anomaly Detector', () => {
-  it('should return anomalies for a sample input', () => {
+  it('returns time indexed hits', () => {
     const sample = new Float32Array([0.1, 0.2, 0.9, 0.3, 0.8]);
     const result = detectAnomalies(sample);
-    expect(Array.isArray(result)).toBe(true);
-    expect(result.length).toBeGreaterThanOrEqual(0);
+    expect(result.length).toBe(2);
+    expect(result[0].time).toBe(2);
+    expect(result[1].time).toBe(4);
   });
 
   it('should return an empty array for no anomalies', () => {
@@ -14,12 +15,10 @@ describe('Anomaly Detector', () => {
     expect(result).toEqual([]);
   });
 
-  it('should detect anomalies with confidence above threshold', () => {
-    const sample = new Float32Array([0.5, 0.6, 0.7, 0.8, 0.9]);
+  it('includes frequency and confidence', () => {
+    const sample = new Float32Array([0.6, 0.7]);
     const result = detectAnomalies(sample);
-    result.forEach((anomaly) => {
-      expect(anomaly.confidence).toBeGreaterThanOrEqual(0);
-      expect(anomaly.freq).toBeGreaterThan(0);
-    });
+    expect(result[0].freq).toBeGreaterThan(0);
+    expect(result[0].confidence).toBe(0.6);
   });
 });

--- a/tests/signal.test.ts
+++ b/tests/signal.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { clamp, ema } from '../src/utils/signal';
+import { clamp, ema, fft } from '../src/utils/signal';
 
 test('clamp bounds', () => {
   assert.strictEqual(clamp(2,0,1),1);
@@ -10,4 +10,12 @@ test('clamp bounds', () => {
 test('ema progress', () => {
   const out = ema(0,1,0.5);
   assert.strictEqual(out,0.5);
+});
+
+test('fft peak detection', () => {
+  const N = 8;
+  const sine = new Float32Array(Array.from({length:N}, (_,n)=>Math.sin(2*Math.PI*n/N)));
+  const spectrum = fft(sine);
+  const maxIndex = spectrum.reduce((m,v,i)=> v > spectrum[m] ? i : m, 0);
+  assert.strictEqual(maxIndex,1);
 });


### PR DESCRIPTION
## Summary
- implement SpectralWaterfall component for rendering FFT slices
- add FFT utility and example usage in SessionScreen
- update anomaly detector to emit time-indexed hits

## Testing
- `npm test`
- `node --test --import tsx tests/detector.test.ts` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aec9fb8320832eb57bad29396f213b