### PR TITLE
feat: add prompt suggestion service

### DIFF
--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -8,6 +8,7 @@ import Toggle from '../components/Toggle';
 import { speakEsmera } from '../core/audio/tts';
 import { useTranscription } from '../core/audio/transcription';
 import { detectAnomalies, setSensitivity } from '../core/anomaly/detector';
+import { generatePromptSuggestions } from '../services/promptGenerator';
 
 export default function SessionScreen({navigation}:any){
   const { engine, session, start, stop, sync } = useSession();
@@ -15,12 +16,21 @@ export default function SessionScreen({navigation}:any){
   const [amp,setAmp] = useState(0);
   const [mode,setMode] = useState<'Standard'|'Mana'|'Reverse'|'DreamLink'|'Shadow'|'CallAndResponse'>('Standard');
   const [hits,setHits] = useState<any[]>([]);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
 
   useEffect(()=> engine.level$(setAmp), [engine]);
   useEffect(()=>{ const det = setInterval(()=>{
     const arr = detectAnomalies(new Float32Array(10));
     if(arr.length) setHits(h=>[...h,...arr]);
   },1000); return ()=>clearInterval(det); },[]);
+
+  useEffect(()=>{
+    if(text){
+      generatePromptSuggestions(text).then(setSuggestions).catch(()=>setSuggestions([]));
+    } else {
+      setSuggestions([]);
+    }
+  },[text]);
 
   const onSpeak = ()=> speakEsmera(text || 'Welcome to EchoVoid.', !text);
 
@@ -40,6 +50,15 @@ export default function SessionScreen({navigation}:any){
   <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Transcript</Text>
   <Text style={{color:colors.neon}}>{text || '…listening…'}</Text>
     <Text style={{color:colors.neon2, opacity:conf==null?0.5:1}}>confidence: {conf==null?'—':Math.round(conf*100)+'%'}</Text>
+  {suggestions.length>0 && (
+    <View style={{marginTop:8}}>
+      {suggestions.map((s,i)=>(
+        <Pressable key={i} onPress={()=>speakEsmera(s)}>
+          <Text style={{color:colors.neon2}}>{s}</Text>
+        </Pressable>
+      ))}
+    </View>
+  )}
 
   <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Anomalies</Text>
   {hits.map((h,i)=>(<Text key={i} style={{color:colors.neon2}}>{`hit @${Math.round(h.freq)}Hz (${Math.round(h.confidence*100)}%)`}</Text>))}

--- a/src/services/promptGenerator.ts
+++ b/src/services/promptGenerator.ts
@@ -1,0 +1,33 @@
+const fallbackPrompts = [
+  'Can you elaborate on that?',
+  'What are you sensing now?',
+  'Tell us something unexpected.'
+];
+
+export async function generatePromptSuggestions(context: string): Promise<string[]> {
+  const key = (globalThis as any).OPENAI_API_KEY as string | undefined;
+  if (!key) return fallbackPrompts;
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${key}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: 'You generate concise follow-up prompts.' },
+          { role: 'user', content: `Provide three follow-up prompts for: ${context}` }
+        ]
+      })
+    });
+    const json = await res.json();
+    const text: string = json?.choices?.[0]?.message?.content || '';
+    const lines = text.split('\n').map((l: string) => l.replace(/^[-*\d\.\s]+/, '').trim()).filter(Boolean);
+    return lines.length ? lines.slice(0, 3) : fallbackPrompts;
+  } catch (err) {
+    console.warn('prompt generation failed', err);
+    return fallbackPrompts;
+  }
+}


### PR DESCRIPTION
## Summary
- add basic AI prompt generator service
- show prompt suggestions under transcript in sessions
- speak suggestions when tapped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeca27c7d4832e8cdff670eb886def