### PR TITLE
feat(theme): support selectable variants

### DIFF
--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -1,9 +1,24 @@
 import React from 'react';
 import { Pressable, Text } from 'react-native';
+import { useTheme } from '../theme/theme';
+
 export default function Toggle({label, active, onPress}:{label:string;active:boolean;onPress:()=>void}){
+  const { theme } = useTheme();
+  const c = theme.colors;
   return (
-    <Pressable onPress={onPress} style={{paddingVertical:8,paddingHorizontal:12,borderRadius:8,backgroundColor:active?'#00D9FF22':'#171717',borderWidth:1,borderColor:active?'#00D9FF':'#262626',marginRight:8}}>
-      <Text style={{color:active?'#00D9FF':'#F2F2F2'}}>{label}</Text>
+    <Pressable
+      onPress={onPress}
+      style={{
+        paddingVertical:8,
+        paddingHorizontal:12,
+        borderRadius:8,
+        backgroundColor:active ? `${c.accent}22` : c.card,
+        borderWidth:1,
+        borderColor:active ? c.accent : c.line,
+        marginRight:8,
+      }}
+    >
+      <Text style={{color:active ? c.accent : c.text}}>{label}</Text>
     </Pressable>
   );
 }

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import { navTheme } from '../theme/theme';
+import { useTheme } from '../theme/theme';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import HomeScreen from '../screens/HomeScreen';
@@ -30,10 +30,11 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 function AppNavigator() {
   // Log navigation container state
   console.log('[AppNavigator] Navigation state:', Stack.Navigator);
+  const { theme } = useTheme();
 
   return (
     <NavigationContainer
-      theme={navTheme}
+      theme={theme.navTheme}
       onStateChange={(state) => console.log('[AppNavigator] Navigation state changed:', state)}
     >
       <Stack.Navigator initialRouteName="Welcome" screenOptions={{ headerShown: false }}>

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import { View, Text, Pressable, ScrollView } from 'react-native';
 import { useSession } from '../context/SessionContext';
-import { colors } from '../theme/colors';
+import { useTheme } from '../theme/theme';
 import Meter from '../components/Meter';
 import Visualizer from '../components/Visualizer';
 import Toggle from '../components/Toggle';
@@ -11,10 +11,16 @@ import { detectAnomalies, setSensitivity } from '../core/anomaly/detector';
 
 export default function SessionScreen({navigation}:any){
   const { engine, session, start, stop, sync } = useSession();
+  const { theme } = useTheme();
+  const { colors } = theme;
   const { text, conf, listening, supported, start:startASR, stop:stopASR } = useTranscription();
   const [amp,setAmp] = useState(0);
   const [mode,setMode] = useState<'Standard'|'Mana'|'Reverse'|'DreamLink'|'Shadow'|'CallAndResponse'>('Standard');
   const [hits,setHits] = useState<any[]>([]);
+
+  const btn = { backgroundColor:colors.card, borderWidth:1, borderColor:colors.neon, paddingVertical:10, paddingHorizontal:14, borderRadius:10 };
+  const btnt = { color:colors.neon, fontWeight:"bold" };
+  const btnGhost = { backgroundColor:colors.bg, borderWidth:1, borderColor:colors.line, paddingVertical:10, paddingHorizontal:14, borderRadius:10 };
 
   useEffect(()=> engine.level$(setAmp), [engine]);
   useEffect(()=>{ const det = setInterval(()=>{
@@ -46,19 +52,16 @@ export default function SessionScreen({navigation}:any){
 
       <View style={{flexDirection:'row', gap:12, marginTop:8}}>
         {!session
-          ? <Pressable onPress={()=>start(mode)} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Start</Text></Pressable>
-          : <Pressable onPress={()=>stop()} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Stop</Text></Pressable>}
+          ? <Pressable onPress={()=>start(mode)} style={btn}><Text style={btnt}>Start</Text></Pressable>
+          : <Pressable onPress={()=>stop()} style={btn}><Text style={btnt}>Stop</Text></Pressable>}
         {supported
           ? !listening
-            ? <Pressable onPress={startASR} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Listen</Text></Pressable>
-            : <Pressable onPress={stopASR} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Stop ASR</Text></Pressable>
-          : <Pressable onPress={onSpeak} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Speak</Text></Pressable>}
+            ? <Pressable onPress={startASR} style={btn}><Text style={btnt}>Listen</Text></Pressable>
+            : <Pressable onPress={stopASR} style={btn}><Text style={btnt}>Stop ASR</Text></Pressable>
+          : <Pressable onPress={onSpeak} style={btn}><Text style={btnt}>Speak</Text></Pressable>}
       <Pressable onPress={()=>navigation.navigate('Logbook')} style={btnGhost}><Text style={{color:colors.text}}>Logbook</Text></Pressable>
       <Pressable onPress={sync} style={btnGhost}><Text style={{color:colors.text}}>Sync</Text></Pressable>
       </View>
     </ScrollView>
   );
 }
-const btn = { backgroundColor:'#0e2f36', borderWidth:1, borderColor:colors.neon, paddingVertical:10, paddingHorizontal:14, borderRadius:10 };
-const btnt = { color:colors.neon, fontWeight:"bold" };
-const btnGhost = { backgroundColor:'#141414', borderWidth:1, borderColor:'#2a2a2a', paddingVertical:10, paddingHorizontal:14, borderRadius:10 };

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,23 +1,34 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { colors } from '../theme/colors';
+import Toggle from '../components/Toggle';
+import { useTheme } from '../theme/theme';
 
 export default function SettingsScreen({ navigation }: { navigation: any }) {
   // Log navigation prop
   console.log('[SettingsScreen] navigation prop:', navigation);
+  const { variant, setVariant, theme } = useTheme();
+  const { colors } = theme;
 
   return (
-    <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
+    <LinearGradient colors={[colors.bg, colors.bg, colors.card]} style={{ flex: 1 }}>
       <View style={styles.container}>
-        <Text style={styles.h1}>Settings</Text>
-        <Text style={styles.p}>(Add prefs like voice, theme, logging here)</Text>
+        <Text style={[styles.h1, { color: colors.text }]}>Settings</Text>
+        <Text style={[styles.p, { color: colors.subtext }]}> (Add prefs like voice, theme, logging here)</Text>
+        <View style={{ marginTop: 24, alignItems: 'center' }}>
+          <Text style={[styles.h2, { color: colors.text }]}>Theme</Text>
+          <View style={{ flexDirection: 'row', marginTop: 8 }}>
+            <Toggle label="Default" active={variant === 'default'} onPress={() => setVariant('default')} />
+            <Toggle label="High Contrast" active={variant === 'highContrast'} onPress={() => setVariant('highContrast')} />
+          </View>
+        </View>
       </View>
     </LinearGradient>
   );
 }
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
-  p: { color: colors.subtext, marginTop: 8 },
+  h1: { fontSize: 28, fontWeight: '700' },
+  h2: { fontSize: 20, fontWeight: '600' },
+  p: { marginTop: 8 },
 });

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -1,48 +1,72 @@
-// Custom theme colors for app screens (includes all keys)
-export const themeColors = {
-  ...colors,
-};
-import React, { PropsWithChildren } from 'react';
+import React, { createContext, useContext, useState, PropsWithChildren } from 'react';
+import { View } from 'react-native';
 import { DefaultTheme, Theme as NavTheme } from '@react-navigation/native';
-import { colors } from './colors';
+import { colors as baseColors } from './colors';
+import { highContrastColors } from './variants/highContrast';
 
-export const navTheme: NavTheme = {
+export type ThemeVariant = 'default' | 'highContrast';
+
+export interface Theme {
+  colors: typeof baseColors;
+  navTheme: NavTheme;
+}
+
+const createNavTheme = (c: typeof baseColors): NavTheme => ({
   ...DefaultTheme,
   colors: {
     ...DefaultTheme.colors,
-    background: colors.bg,
-    card: colors.card,
-    text: colors.text,
-    border: colors.line,
-    primary: colors.accent,
-    notification: colors.neon,
+    background: c.bg,
+    card: c.card,
+    text: c.text,
+    border: c.line,
+    primary: c.accent,
+    notification: c.neon,
   },
+});
+
+const defaultTheme: Theme = {
+  colors: baseColors,
+  navTheme: createNavTheme(baseColors),
 };
 
-import { ImageBackground, StyleSheet, View, Animated, Easing } from 'react-native';
+const hcColors = highContrastColors;
+const highContrast: Theme = {
+  colors: hcColors,
+  navTheme: createNavTheme(hcColors),
+};
+
+export const themes: Record<ThemeVariant, Theme> = {
+  default: defaultTheme,
+  highContrast,
+};
+
+// Backwards compatibility exports
+export const themeColors = themes.default.colors;
+export const navTheme = themes.default.navTheme;
+
+interface ThemeContextType {
+  variant: ThemeVariant;
+  theme: Theme;
+  setVariant: (v: ThemeVariant) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  variant: 'default',
+  theme: themes.default,
+  setVariant: () => {},
+});
 
 export function ThemeProvider({ children }: PropsWithChildren) {
+  const [variant, setVariant] = useState<ThemeVariant>('default');
+  const theme = themes[variant];
 
   return (
-    <View style={{ flex: 1 }}>
-      {/* Gradient background for astral/spiritual effect */}
-      <View style={styles.gradientBg}>
-        {children}
-      </View>
-    </View>
+    <ThemeContext.Provider value={{ variant, theme, setVariant }}>
+      <View style={{ flex: 1, backgroundColor: theme.colors.bg }}>{children}</View>
+    </ThemeContext.Provider>
   );
 }
 
-const styles = StyleSheet.create({
-  gradientBg: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    zIndex: -1,
-    backgroundColor: '#2C1B0F', // lighter brown for better contrast
-  },
-  bg: { flex: 1, width: '100%', height: '100%', justifyContent: 'center', backgroundColor: '#2C1B0F' },
-  overlay: { flex: 1, opacity: 0.08, justifyContent: 'center' }, // lower overlay opacity for brightness
-});
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/src/theme/variants/highContrast.ts
+++ b/src/theme/variants/highContrast.ts
@@ -1,7 +1,19 @@
 import { colors } from '../colors';
-export const HIGH_CONTRAST = {
-  background: colors.bg,
+
+// Full color map for high contrast variant
+export const highContrastColors = {
+  ...colors,
+  bg: '#000000',
+  card: '#000000',
   text: '#FFFFFF',
-  primary: '#00FFFF',
-  accent: '#FF00FF'
+  subtext: '#FFFFFF',
+  neon: '#00FFFF',
+  neon2: '#FF00FF',
+  accent: '#FF00FF',
+  accent2: '#00FFFF',
+  overlay: 'rgba(255,255,255,0.1)',
+  danger: '#FF5555',
+  line: '#FFFFFF',
 };
+
+export const HIGH_CONTRAST = highContrastColors;


### PR DESCRIPTION
## Summary
- add theme context with default and high-contrast variants
- switch component colors to theme references
- add settings toggle to switch theme variant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeca31c850832e93d324d582cc81ec