### PR TITLE
feat: add live session sharing

### DIFF
--- a/src/core/live/sessionShare.ts
+++ b/src/core/live/sessionShare.ts
@@ -1,21 +1,69 @@
-// Placeholder for shared live sessions and invitations
-export type Participant = { id:string; name:string };
+// WebSocket client for live session sharing
+export type Participant = { id: string; name: string };
+
+type MessageHandler = (data: { text: string; id?: string }) => void;
+type AnomalyHandler = (data: any) => void;
+
+let socket: WebSocket | null = null;
+let msgHandlers: MessageHandler[] = [];
+let anomalyHandlers: AnomalyHandler[] = [];
+
+function setupSocket(id: string) {
+  // Using a public echo server for demo purposes
+  const url = `wss://echo.websocket.events/?session=${id}`;
+  socket = new WebSocket(url);
+  socket.onmessage = (ev) => {
+    try {
+      const payload = JSON.parse(ev.data);
+      if (payload.type === 'message') {
+        msgHandlers.forEach((h) => h(payload));
+      } else if (payload.type === 'anomaly') {
+        anomalyHandlers.forEach((h) => h(payload.data));
+      }
+    } catch (e) {
+      // ignore malformed messages
+    }
+  };
+  socket.onclose = () => {
+    socket = null;
+  };
+}
+
 export function createLiveSession() {
-  console.log('Creating live session...');
-  // Placeholder implementation
-  return { id: Date.now().toString(), participants: [] };
+  const id = Date.now().toString();
+  setupSocket(id);
+  return { id, participants: [] as Participant[] };
 }
 
 export function joinLiveSession(id: string) {
-  console.log(`Joining live session with ID: ${id}`);
-  // Placeholder implementation
+  setupSocket(id);
   return { success: true };
 }
 
-export function onAnomaly(cb: (data: any) => void) {
-  console.log('Subscribing to anomalies...');
-  // Placeholder implementation
-  setInterval(() => {
-    cb({ time: Date.now(), freq: Math.random() * 5000, confidence: Math.random() });
-  }, 5000);
+export function leaveLiveSession() {
+  if (socket) {
+    socket.close();
+    socket = null;
+  }
 }
+
+export function sendMessage(text: string) {
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({ type: 'message', text }));
+  }
+}
+
+export function sendAnomaly(data: any) {
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({ type: 'anomaly', data }));
+  }
+}
+
+export function onMessage(cb: MessageHandler) {
+  msgHandlers.push(cb);
+}
+
+export function onAnomaly(cb: AnomalyHandler) {
+  anomalyHandlers.push(cb);
+}
+

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -8,6 +8,7 @@ import Toggle from '../components/Toggle';
 import { speakEsmera } from '../core/audio/tts';
 import { useTranscription } from '../core/audio/transcription';
 import { detectAnomalies, setSensitivity } from '../core/anomaly/detector';
+import { createLiveSession, leaveLiveSession, sendMessage, sendAnomaly, onMessage, onAnomaly } from '../core/live/sessionShare';
 
 export default function SessionScreen({navigation}:any){
   const { engine, session, start, stop, sync } = useSession();
@@ -15,12 +16,29 @@ export default function SessionScreen({navigation}:any){
   const [amp,setAmp] = useState(0);
   const [mode,setMode] = useState<'Standard'|'Mana'|'Reverse'|'DreamLink'|'Shadow'|'CallAndResponse'>('Standard');
   const [hits,setHits] = useState<any[]>([]);
+  const [remoteMsgs,setRemoteMsgs] = useState<string[]>([]);
+  const [remoteHits,setRemoteHits] = useState<any[]>([]);
+  const [sharing,setSharing] = useState(false);
 
   useEffect(()=> engine.level$(setAmp), [engine]);
   useEffect(()=>{ const det = setInterval(()=>{
     const arr = detectAnomalies(new Float32Array(10));
-    if(arr.length) setHits(h=>[...h,...arr]);
-  },1000); return ()=>clearInterval(det); },[]);
+    if(arr.length){
+      setHits(h=>[...h,...arr]);
+      if(sharing) arr.forEach(a=>sendAnomaly(a));
+    }
+  },1000); return ()=>clearInterval(det); },[sharing]);
+
+  useEffect(()=>{
+    if(!sharing) return;
+    const msgHandler = (m:{text:string})=> setRemoteMsgs(r=>[...r,m.text]);
+    const anoHandler = (a:any)=> setRemoteHits(h=>[...h,a]);
+    onMessage(msgHandler);
+    onAnomaly(anoHandler);
+    return ()=>{ leaveLiveSession(); };
+  },[sharing]);
+
+  useEffect(()=>{ if(sharing && text) sendMessage(text); },[text, sharing]);
 
   const onSpeak = ()=> speakEsmera(text || 'Welcome to EchoVoid.', !text);
 
@@ -40,9 +58,14 @@ export default function SessionScreen({navigation}:any){
   <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Transcript</Text>
   <Text style={{color:colors.neon}}>{text || '…listening…'}</Text>
     <Text style={{color:colors.neon2, opacity:conf==null?0.5:1}}>confidence: {conf==null?'—':Math.round(conf*100)+'%'}</Text>
+    {remoteMsgs.map((m,i)=>(<Text key={`rm${i}`} style={{color:colors.neon2}}>{m}</Text>))}
 
   <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Anomalies</Text>
-  {hits.map((h,i)=>(<Text key={i} style={{color:colors.neon2}}>{`hit @${Math.round(h.freq)}Hz (${Math.round(h.confidence*100)}%)`}</Text>))}
+  {[...hits, ...remoteHits].map((h,i)=> (
+    <Text key={i} style={{color:colors.neon2}}>
+      {`hit @${Math.round(h.freq)}Hz (${Math.round(((h as any).confidence ?? 0)*100)}%)`}
+    </Text>
+  ))}
 
       <View style={{flexDirection:'row', gap:12, marginTop:8}}>
         {!session
@@ -53,6 +76,9 @@ export default function SessionScreen({navigation}:any){
             ? <Pressable onPress={startASR} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Listen</Text></Pressable>
             : <Pressable onPress={stopASR} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Stop ASR</Text></Pressable>
           : <Pressable onPress={onSpeak} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Speak</Text></Pressable>}
+        {!sharing
+          ? <Pressable onPress={()=>{ createLiveSession(); setSharing(true); }} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Share</Text></Pressable>
+          : <Pressable onPress={()=>{ setSharing(false); leaveLiveSession(); }} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Stop Share</Text></Pressable>}
       <Pressable onPress={()=>navigation.navigate('Logbook')} style={btnGhost}><Text style={{color:colors.text}}>Logbook</Text></Pressable>
       <Pressable onPress={sync} style={btnGhost}><Text style={{color:colors.text}}>Sync</Text></Pressable>
       </View>


### PR DESCRIPTION
## Summary
- implement basic WebSocket client for live session sharing
- add share controls and remote message/anomaly display on Session screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeca0e269c832ea221979def361cfd