### PR TITLE
feat: centralize typography and spacing

### DIFF
--- a/components/controls/Chip.tsx
+++ b/components/controls/Chip.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 export default function Chip({ options, value, onChange }: {
   options: string[];
   value: string;
@@ -22,7 +24,12 @@ export default function Chip({ options, value, onChange }: {
   );
 }
 const styles = StyleSheet.create({
-  row: { flexDirection: 'row', gap: 8, marginVertical: 8 },
-  chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 2 },
-  text: { fontWeight: '600', fontSize: 14 },
+  row: { flexDirection: 'row', gap: SPACING.sm, marginVertical: SPACING.sm },
+  chip: {
+    paddingVertical: SPACING.sm - SPACING.xxs,
+    paddingHorizontal: SPACING.sm + SPACING.xs + SPACING.xxs,
+    borderRadius: SPACING.md,
+    margin: SPACING.xxs,
+  },
+  text: { fontWeight: FONT_WEIGHTS.semibold, fontSize: FONT_SIZES.sm },
 });

--- a/components/controls/Knob.tsx
+++ b/components/controls/Knob.tsx
@@ -3,6 +3,8 @@ import { View, Text, PanResponder, StyleSheet } from 'react-native';
 import Animated, { useSharedValue, useAnimatedProps, withSpring } from 'react-native-reanimated';
 import Svg, { Circle, G, Path as SvgPath } from 'react-native-svg';
 import { useTheme } from '../../theme';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 const TICK_COUNT = 18;
 
 function polarToCartesian(cx: number, cy: number, r: number, angle: number) {
@@ -94,6 +96,6 @@ export default function Knob({ value, onChange, min = 0, max = 1, step = 0.01, s
   );
 }
 const styles = StyleSheet.create({
-  label: { fontWeight: '600', marginTop: 2 },
-  value: { fontWeight: '700', fontSize: 16 },
+  label: { fontWeight: FONT_WEIGHTS.semibold, marginTop: SPACING.xxs },
+  value: { fontWeight: FONT_WEIGHTS.bold, fontSize: FONT_SIZES.md },
 });

--- a/components/controls/Slider.tsx
+++ b/components/controls/Slider.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { useTheme } from '../../theme';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_WEIGHTS } from '../../src/theme/typography';
 export default function EVoidSlider({ value, onChange, min = 0, max = 1, step = 0.01, label, format }: {
   value: number;
   onChange: (v: number) => void;
@@ -31,8 +33,8 @@ export default function EVoidSlider({ value, onChange, min = 0, max = 1, step = 
   );
 }
 const styles = StyleSheet.create({
-  wrap: { width: '100%', marginVertical: 8 },
-  label: { marginBottom: 4, fontWeight: '600' },
+  wrap: { width: '100%', marginVertical: SPACING.sm },
+  label: { marginBottom: SPACING.xs, fontWeight: FONT_WEIGHTS.semibold },
   slider: { width: '100%' },
-  value: { fontWeight: '700', fontSize: 15, marginTop: 2 },
+  value: { fontWeight: FONT_WEIGHTS.bold, fontSize: 15, marginTop: SPACING.xxs },
 });

--- a/components/controls/Timer.tsx
+++ b/components/controls/Timer.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withRepeat, withTiming } from 'react-native-reanimated';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
+import { SPACING } from '../../src/theme/spacing';
 
 export default function Timer({ ms }: { ms: number }) {
   const mm = Math.floor(ms / 60000).toString().padStart(2, '0');
@@ -15,5 +17,5 @@ export default function Timer({ ms }: { ms: number }) {
   return <Animated.Text style={[styles.timer, style]}>{mm}:{ss}</Animated.Text>;
 }
 const styles = StyleSheet.create({
-  timer: { fontSize: 22, fontWeight: '700', letterSpacing: 1, color: '#fff', textAlign: 'center' },
+  timer: { fontSize: FONT_SIZES.xl + SPACING.xxs, fontWeight: FONT_WEIGHTS.bold, letterSpacing: 1, color: '#fff', textAlign: 'center' },
 });

--- a/components/logbook/SessionDetail.tsx
+++ b/components/logbook/SessionDetail.tsx
@@ -3,6 +3,8 @@ import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { Audio } from 'expo-av';
 import EVoidButton from '../ui/EVoidButton';
 import { shareSessionZip } from '../../services/export/zipSession';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 
 export default function SessionDetail({ route }: any) {
   const session = route?.params?.session;
@@ -46,7 +48,7 @@ export default function SessionDetail({ route }: any) {
       <EVoidButton
         label={playing ? 'Stop Playback' : 'Play Recording'}
         onPress={handlePlay}
-        style={{ marginVertical: 16, minWidth: 140 }}
+        style={{ marginVertical: SPACING.md, minWidth: 140 }}
       />
       <Text style={styles.label}>Anomaly Timestamps:</Text>
       {session?.anomalies?.length ? (
@@ -56,13 +58,13 @@ export default function SessionDetail({ route }: any) {
       ) : (
         <Text style={styles.value}>None</Text>
       )}
-  <EVoidButton label="Export Session" onPress={() => shareSessionZip(session)} style={{ marginTop: 24 }} />
+  <EVoidButton label="Export Session" onPress={() => shareSessionZip(session)} style={{ marginTop: SPACING.lg }} />
     </ScrollView>
   );
 }
 const styles = StyleSheet.create({
-  detail: { flex: 1, padding: 20, backgroundColor: '#111' },
-  title: { fontSize: 24, fontWeight: '800', color: '#fff', marginBottom: 16 },
-  label: { color: '#aaa', fontWeight: '600', marginTop: 12 },
-  value: { color: '#fff', fontSize: 15, marginTop: 2 },
+  detail: { flex: 1, padding: SPACING.md + SPACING.xs, backgroundColor: '#111' },
+  title: { fontSize: FONT_SIZES.xxl, fontWeight: FONT_WEIGHTS.extrabold, color: '#fff', marginBottom: SPACING.md },
+  label: { color: '#aaa', fontWeight: FONT_WEIGHTS.semibold, marginTop: SPACING.sm + SPACING.xs },
+  value: { color: '#fff', fontSize: 15, marginTop: SPACING.xxs },
 });

--- a/components/logbook/SessionItem.tsx
+++ b/components/logbook/SessionItem.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 // TODO: Show session summary, type, date, and quick actions
 export default function SessionItem({ session, onDelete, onView }: { session: any; onDelete: () => void; onView: () => void }) {
   return (
@@ -15,11 +17,11 @@ export default function SessionItem({ session, onDelete, onView }: { session: an
   );
 }
 const styles = StyleSheet.create({
-  item: { padding: 16, borderRadius: 12, backgroundColor: '#222', marginVertical: 6 },
-  type: { color: '#fff', fontWeight: '700', fontSize: 16 },
-  date: { color: '#aaa', fontSize: 13, marginTop: 2 },
-  info: { color: '#8ff', fontSize: 13, marginTop: 4 },
-  actions: { flexDirection: 'row', marginTop: 8 },
-  actionButton: { marginRight: 12, padding: 8, backgroundColor: '#444', borderRadius: 8 },
+  item: { padding: SPACING.md, borderRadius: SPACING.sm + SPACING.xs, backgroundColor: '#222', marginVertical: SPACING.sm - SPACING.xxs },
+  type: { color: '#fff', fontWeight: FONT_WEIGHTS.bold, fontSize: FONT_SIZES.md },
+  date: { color: '#aaa', fontSize: 13, marginTop: SPACING.xxs },
+  info: { color: '#8ff', fontSize: 13, marginTop: SPACING.xs },
+  actions: { flexDirection: 'row', marginTop: SPACING.sm },
+  actionButton: { marginRight: SPACING.sm + SPACING.xs, padding: SPACING.sm, backgroundColor: '#444', borderRadius: SPACING.sm },
   actionText: { color: '#fff', fontSize: 13 },
 });

--- a/components/ui/EVoidButton.tsx
+++ b/components/ui/EVoidButton.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 
 type Props = {
   label: string;
@@ -36,6 +38,12 @@ export default function EVoidButton({ label, onPress, variant = 'solid', style, 
   );
 }
 const styles = StyleSheet.create({
-  btn: { paddingVertical: 14, paddingHorizontal: 20, borderRadius: 14, alignItems: 'center', marginVertical: 4 },
-  text: { fontSize: 16, fontWeight: '700', letterSpacing: 0.4 },
+  btn: {
+    paddingVertical: SPACING.sm + SPACING.xs + SPACING.xxs,
+    paddingHorizontal: SPACING.md + SPACING.xs,
+    borderRadius: SPACING.sm + SPACING.xs + SPACING.xxs,
+    alignItems: 'center',
+    marginVertical: SPACING.xs,
+  },
+  text: { fontSize: FONT_SIZES.md, fontWeight: FONT_WEIGHTS.bold, letterSpacing: 0.4 },
 });

--- a/components/ui/EVoidChip.tsx
+++ b/components/ui/EVoidChip.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 
 type Props = { label: string; selected?: boolean; style?: ViewStyle | ViewStyle[] };
 export default function EVoidChip({ label, selected, style }: Props) {
@@ -12,6 +14,11 @@ export default function EVoidChip({ label, selected, style }: Props) {
   );
 }
 const styles = StyleSheet.create({
-  chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 4 },
-  text: { fontWeight: '600', fontSize: 14 },
+  chip: {
+    paddingVertical: SPACING.sm - SPACING.xxs,
+    paddingHorizontal: SPACING.sm + SPACING.xs + SPACING.xxs,
+    borderRadius: SPACING.md,
+    margin: SPACING.xs,
+  },
+  text: { fontWeight: FONT_WEIGHTS.semibold, fontSize: FONT_SIZES.sm },
 });

--- a/components/ui/EVoidDialog.tsx
+++ b/components/ui/EVoidDialog.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Modal, View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 
 type Props = { visible: boolean; title: string; children: React.ReactNode; onClose: () => void };
 export default function EVoidDialog({ visible, title, children, onClose }: Props) {
@@ -18,6 +20,6 @@ export default function EVoidDialog({ visible, title, children, onClose }: Props
 }
 const styles = StyleSheet.create({
   overlay: { flex: 1, backgroundColor: '#0009', justifyContent: 'center', alignItems: 'center' },
-  dialog: { borderRadius: 18, padding: 24, minWidth: 260 },
-  title: { fontWeight: '700', fontSize: 18, marginBottom: 12 },
+  dialog: { borderRadius: SPACING.md + SPACING.xxs, padding: SPACING.lg, minWidth: 260 },
+  title: { fontWeight: FONT_WEIGHTS.bold, fontSize: FONT_SIZES.lg, marginBottom: SPACING.sm + SPACING.xs },
 });

--- a/components/ui/EVoidListItem.tsx
+++ b/components/ui/EVoidListItem.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 
 type Props = { title: string; subtitle?: string; right?: React.ReactNode; style?: ViewStyle | ViewStyle[] };
 export default function EVoidListItem({ title, subtitle, right, style }: Props) {
@@ -16,7 +18,7 @@ export default function EVoidListItem({ title, subtitle, right, style }: Props) 
   );
 }
 const styles = StyleSheet.create({
-  item: { flexDirection: 'row', alignItems: 'center', padding: 16, borderRadius: 12, marginVertical: 4 },
-  title: { fontWeight: '700', fontSize: 16 },
-  subtitle: { fontSize: 13, marginTop: 2 },
+  item: { flexDirection: 'row', alignItems: 'center', padding: SPACING.md, borderRadius: SPACING.sm + SPACING.xs, marginVertical: SPACING.xs },
+  title: { fontWeight: FONT_WEIGHTS.bold, fontSize: FONT_SIZES.md },
+  subtitle: { fontSize: 13, marginTop: SPACING.xxs },
 });

--- a/components/ui/EVoidToast.tsx
+++ b/components/ui/EVoidToast.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_WEIGHTS } from '../../src/theme/typography';
 
 type Props = { message: string; type?: 'info' | 'danger' | 'success' };
 export default function EVoidToast({ message, type = 'info' }: Props) {
@@ -13,6 +15,16 @@ export default function EVoidToast({ message, type = 'info' }: Props) {
   );
 }
 const styles = StyleSheet.create({
-  toast: { position: 'absolute', bottom: 32, left: 24, right: 24, backgroundColor: '#222E', borderRadius: 12, borderWidth: 2, padding: 16, alignItems: 'center' },
-  text: { fontWeight: '700', fontSize: 15 },
+  toast: {
+    position: 'absolute',
+    bottom: SPACING.xl,
+    left: SPACING.lg,
+    right: SPACING.lg,
+    backgroundColor: '#222E',
+    borderRadius: SPACING.sm + SPACING.xs,
+    borderWidth: 2,
+    padding: SPACING.md,
+    alignItems: 'center',
+  },
+  text: { fontWeight: FONT_WEIGHTS.bold, fontSize: 15 },
 });

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,22 @@
+# Style Guide
+
+Reusable design tokens live in `src/theme`.
+
+## Typography
+
+- `FONT_SIZES` provides named font size values (xs, sm, md, lg, xl, xxl, xxxl, display).
+- `FONT_WEIGHTS` exposes weight keywords like `regular`, `bold`, etc.
+
+```ts
+import { FONT_SIZES, FONT_WEIGHTS } from 'src/theme/typography';
+```
+
+## Spacing
+
+Use spacing constants instead of magic numbers.
+
+```ts
+import { SPACING } from 'src/theme/spacing';
+```
+
+These tokens help keep layout and text styles consistent across screens and components.

--- a/screens/Onboarding/HowTo.tsx
+++ b/screens/Onboarding/HowTo.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 
 export default function OnboardingHowTo({ navigation }: any) {
   return (
@@ -18,8 +20,8 @@ export default function OnboardingHowTo({ navigation }: any) {
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: SPACING.xl, backgroundColor: '#111' },
+  title: { fontSize: FONT_SIZES.xxxl, fontWeight: FONT_WEIGHTS.extrabold, color: '#fff', marginBottom: SPACING.lg },
+  body: { color: '#ccc', fontSize: FONT_SIZES.md, textAlign: 'center', marginBottom: SPACING.xl },
   btn: { minWidth: 160 },
 });

--- a/screens/Onboarding/Intro.tsx
+++ b/screens/Onboarding/Intro.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 
 export default function OnboardingIntro({ navigation }: any) {
   return (
@@ -16,8 +18,8 @@ export default function OnboardingIntro({ navigation }: any) {
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: SPACING.xl, backgroundColor: '#111' },
+  title: { fontSize: FONT_SIZES.xxxl, fontWeight: FONT_WEIGHTS.extrabold, color: '#fff', marginBottom: SPACING.lg },
+  body: { color: '#ccc', fontSize: FONT_SIZES.md, textAlign: 'center', marginBottom: SPACING.xl },
   btn: { minWidth: 160 },
 });

--- a/screens/Onboarding/Privacy.tsx
+++ b/screens/Onboarding/Privacy.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SPACING } from '../../src/theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../../src/theme/typography';
 
 export default function OnboardingPrivacy({ navigation }: any) {
   return (
@@ -19,14 +21,14 @@ export default function OnboardingPrivacy({ navigation }: any) {
       <EVoidButton label="Skip Onboarding" onPress={async () => {
         await AsyncStorage.setItem('onboarded', '1');
         navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
-      }} style={[styles.btn, { marginTop: 16, backgroundColor: '#333' }]} />
+      }} style={[styles.btn, { marginTop: SPACING.md, backgroundColor: '#333' }]} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: SPACING.xl, backgroundColor: '#111' },
+  title: { fontSize: FONT_SIZES.xxxl, fontWeight: FONT_WEIGHTS.extrabold, color: '#fff', marginBottom: SPACING.lg },
+  body: { color: '#ccc', fontSize: FONT_SIZES.md, textAlign: 'center', marginBottom: SPACING.xl },
   btn: { minWidth: 160 },
 });

--- a/src/components/UIButton.tsx
+++ b/src/components/UIButton.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
+import { SPACING } from '../theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../theme/typography';
 
 type Props = {
   label: string;
@@ -32,17 +34,17 @@ export default function UIButton({ label, onPress, style, testID }: Props) {
 
 const styles = StyleSheet.create({
   btn: {
-    paddingVertical: 14,
-    paddingHorizontal: 20,
-    borderRadius: 14,
+    paddingVertical: SPACING.sm + SPACING.xs + SPACING.xxs,
+    paddingHorizontal: SPACING.md + SPACING.xs,
+    borderRadius: SPACING.sm + SPACING.xs + SPACING.xxs,
     backgroundColor: '#111827',
     borderWidth: 1,
     borderColor: 'rgba(255,255,255,0.10)',
   },
   text: {
     color: 'white',
-    fontSize: 16,
-    fontWeight: '700',
+    fontSize: FONT_SIZES.md,
+    fontWeight: FONT_WEIGHTS.bold,
     letterSpacing: 0.4,
   },
 });

--- a/src/screens/ARModeScreen.tsx
+++ b/src/screens/ARModeScreen.tsx
@@ -6,6 +6,8 @@ import { GLView } from 'expo-gl';
 import { Renderer } from 'expo-three';
 import * as THREE from 'three';
 import { colors } from '../theme/colors';
+import { SPACING } from '../theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../theme/typography';
 
 const { width, height } = Dimensions.get('window');
 
@@ -83,7 +85,7 @@ export default function ARModeScreen({ navigation }: any) {
 }
 
 const styles = StyleSheet.create({
-  overlay: { position: 'absolute', top: 0, left: 0, right: 0, padding: 24, alignItems: 'center' },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700', marginTop: 32 },
-  p: { color: colors.subtext, marginTop: 8 },
+  overlay: { position: 'absolute', top: 0, left: 0, right: 0, padding: SPACING.lg, alignItems: 'center' },
+  h1: { color: colors.text, fontSize: FONT_SIZES.xxxl, fontWeight: FONT_WEIGHTS.bold, marginTop: SPACING.xl },
+  p: { color: colors.subtext, marginTop: SPACING.sm },
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -6,6 +6,8 @@ import type { RootStackParamList } from '../navigation/AppNavigator';
 import UIButton from '../components/UIButton';
 import { colors } from '../theme/colors';
 import { hasNativeVoice, startListening } from '../voice/adapter';
+import { SPACING } from '../theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../theme/typography';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
@@ -53,16 +55,22 @@ const styles = StyleSheet.create({
   flex: { flex: 1 },
   container: {
     flex: 1,
-    padding: 24,
+    padding: SPACING.lg,
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 12,
+    gap: SPACING.sm + SPACING.xs,
   },
   title: {
-    color: colors.text, fontSize: 44, fontWeight: '900', letterSpacing: 1, textTransform: 'uppercase',
+    color: colors.text,
+    fontSize: FONT_SIZES.display + SPACING.xs,
+    fontWeight: FONT_WEIGHTS.black,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
   },
   subtitle: {
-    color: colors.subtext, marginTop: 6, marginBottom: 18,
+    color: colors.subtext,
+    marginTop: SPACING.sm - SPACING.xxs,
+    marginBottom: SPACING.md + SPACING.xxs,
   },
   btn: {
     width: '90%',
@@ -80,6 +88,6 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(0,243,255,0.25)',
     shadowColor: colors.neon,
     shadowOpacity: 0.4,
-    shadowRadius: 24,
+    shadowRadius: SPACING.lg,
   },
 });

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -8,6 +8,8 @@ import Toggle from '../components/Toggle';
 import { speakEsmera } from '../core/audio/tts';
 import { useTranscription } from '../core/audio/transcription';
 import { detectAnomalies, setSensitivity } from '../core/anomaly/detector';
+import { SPACING } from '../theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../theme/typography';
 
 export default function SessionScreen({navigation}:any){
   const { engine, session, start, stop, sync } = useSession();
@@ -25,26 +27,26 @@ export default function SessionScreen({navigation}:any){
   const onSpeak = ()=> speakEsmera(text || 'Welcome to EchoVoid.', !text);
 
   return (
-  <ScrollView style={{flex:1, backgroundColor:colors.bg}} contentContainerStyle={{padding:16, gap:16}}>
-      <Text style={{color:colors.text, fontSize:18}}>Mode</Text>
+  <ScrollView style={{flex:1, backgroundColor:colors.bg}} contentContainerStyle={{padding:SPACING.md, gap:SPACING.md}}>
+      <Text style={{color:colors.text, fontSize:FONT_SIZES.lg}}>Mode</Text>
       <View style={{flexDirection:'row', flexWrap:'wrap'}}>
         {(['Standard','Mana','Reverse','DreamLink','Shadow','CallAndResponse'] as const).map(m =>
           <Toggle key={m} label={m} active={mode===m} onPress={()=>setMode(m)} />
         )}
       </View>
 
-  <Text style={{color:colors.text, fontSize:18}}>Sweep / Meter</Text>
+  <Text style={{color:colors.text, fontSize:FONT_SIZES.lg}}>Sweep / Meter</Text>
       <Visualizer level={amp}/>
     <Meter level={amp} color={colors.neon}/>
 
-  <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Transcript</Text>
+  <Text style={{color:colors.text, fontSize:FONT_SIZES.lg, marginTop:SPACING.sm}}>Transcript</Text>
   <Text style={{color:colors.neon}}>{text || '…listening…'}</Text>
     <Text style={{color:colors.neon2, opacity:conf==null?0.5:1}}>confidence: {conf==null?'—':Math.round(conf*100)+'%'}</Text>
 
-  <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Anomalies</Text>
+  <Text style={{color:colors.text, fontSize:FONT_SIZES.lg, marginTop:SPACING.sm}}>Anomalies</Text>
   {hits.map((h,i)=>(<Text key={i} style={{color:colors.neon2}}>{`hit @${Math.round(h.freq)}Hz (${Math.round(h.confidence*100)}%)`}</Text>))}
 
-      <View style={{flexDirection:'row', gap:12, marginTop:8}}>
+      <View style={{flexDirection:'row', gap:SPACING.sm + SPACING.xs, marginTop:SPACING.sm}}>
         {!session
           ? <Pressable onPress={()=>start(mode)} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Start</Text></Pressable>
           : <Pressable onPress={()=>stop()} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Stop</Text></Pressable>}
@@ -59,6 +61,6 @@ export default function SessionScreen({navigation}:any){
     </ScrollView>
   );
 }
-const btn = { backgroundColor:'#0e2f36', borderWidth:1, borderColor:colors.neon, paddingVertical:10, paddingHorizontal:14, borderRadius:10 };
-const btnt = { color:colors.neon, fontWeight:"bold" };
-const btnGhost = { backgroundColor:'#141414', borderWidth:1, borderColor:'#2a2a2a', paddingVertical:10, paddingHorizontal:14, borderRadius:10 };
+const btn = { backgroundColor:'#0e2f36', borderWidth:1, borderColor:colors.neon, paddingVertical:SPACING.sm + SPACING.xxs, paddingHorizontal:SPACING.sm + SPACING.xs + SPACING.xxs, borderRadius:SPACING.sm + SPACING.xxs };
+const btnt = { color:colors.neon, fontWeight:FONT_WEIGHTS.bold };
+const btnGhost = { backgroundColor:'#141414', borderWidth:1, borderColor:'#2a2a2a', paddingVertical:SPACING.sm + SPACING.xxs, paddingHorizontal:SPACING.sm + SPACING.xs + SPACING.xxs, borderRadius:SPACING.sm + SPACING.xxs };

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme/colors';
+import { SPACING } from '../theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../theme/typography';
 
 export default function SettingsScreen({ navigation }: { navigation: any }) {
   // Log navigation prop
@@ -17,7 +19,7 @@ export default function SettingsScreen({ navigation }: { navigation: any }) {
   );
 }
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
-  p: { color: colors.subtext, marginTop: 8 },
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: SPACING.lg },
+  h1: { color: colors.text, fontSize: FONT_SIZES.xxxl, fontWeight: FONT_WEIGHTS.bold },
+  p: { color: colors.subtext, marginTop: SPACING.sm },
 });

--- a/src/screens/TransmissionScreen.tsx
+++ b/src/screens/TransmissionScreen.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme/colors';
+import { SPACING } from '../theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../theme/typography';
 
 // Added type annotation for navigation prop
 const TransmissionScreen = ({ navigation }: { navigation: any }) => {
@@ -19,9 +21,9 @@ const TransmissionScreen = ({ navigation }: { navigation: any }) => {
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
-  p: { color: colors.subtext, marginTop: 8 },
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: SPACING.lg },
+  h1: { color: colors.text, fontSize: FONT_SIZES.xxxl, fontWeight: FONT_WEIGHTS.bold },
+  p: { color: colors.subtext, marginTop: SPACING.sm },
 });
 
 export default TransmissionScreen;

--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -3,6 +3,8 @@ import { View, Text, Pressable, StyleSheet, Dimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../../theme';
 import { themeColors } from '../theme/theme';
+import { SPACING } from '../theme/spacing';
+import { FONT_SIZES, FONT_WEIGHTS } from '../theme/typography';
 
 const { width, height } = Dimensions.get('window');
 
@@ -68,29 +70,29 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 32,
+    padding: SPACING.xl,
   },
   title: {
-    fontSize: 38,
-    fontWeight: '900',
+    fontSize: FONT_SIZES.display - SPACING.xxs,
+    fontWeight: FONT_WEIGHTS.black,
     letterSpacing: 2,
     textShadowColor: '#000a',
     textShadowOffset: { width: 0, height: 2 },
     textShadowRadius: 12,
   },
   subtitle: {
-    fontSize: 18,
-    fontWeight: '500',
-    marginTop: 10,
-    marginBottom: 32,
+    fontSize: FONT_SIZES.lg,
+    fontWeight: FONT_WEIGHTS.medium,
+    marginTop: SPACING.sm + SPACING.xxs,
+    marginBottom: SPACING.xl,
     opacity: 0.85,
     textAlign: 'center',
   },
   button: {
-    marginTop: 18,
-    paddingVertical: 14,
-    paddingHorizontal: 36,
-    borderRadius: 16,
+    marginTop: SPACING.md + SPACING.xxs,
+    paddingVertical: SPACING.sm + SPACING.xs + SPACING.xxs,
+    paddingHorizontal: SPACING.lg + SPACING.sm + SPACING.xs,
+    borderRadius: SPACING.md,
     borderWidth: 2,
     minWidth: 180,
     alignItems: 'center',
@@ -100,8 +102,8 @@ const styles = StyleSheet.create({
     shadowRadius: 8,
   },
   buttonText: {
-    fontSize: 18,
-    fontWeight: '700',
+    fontSize: FONT_SIZES.lg,
+    fontWeight: FONT_WEIGHTS.bold,
     letterSpacing: 1,
   },
 });

--- a/src/theme/spacing.ts
+++ b/src/theme/spacing.ts
@@ -1,0 +1,8 @@
+export const SPACING = {
+  xxs: 2,
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32
+};

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,5 +1,25 @@
+export const FONT_SIZES = {
+  xs: 12,
+  sm: 14,
+  md: 16,
+  lg: 18,
+  xl: 20,
+  xxl: 24,
+  xxxl: 28,
+  display: 40
+};
+
+export const FONT_WEIGHTS = {
+  regular: '400',
+  medium: '500',
+  semibold: '600',
+  bold: '700',
+  extrabold: '800',
+  black: '900'
+};
+
 export const TYPE = {
-  h1: { fontSize: 28, fontWeight: '800', letterSpacing: 0.5 },
-  h2: { fontSize: 20, fontWeight: '700' },
-  body: { fontSize: 16, fontWeight: '400' }
+  h1: { fontSize: FONT_SIZES.xxxl, fontWeight: FONT_WEIGHTS.extrabold, letterSpacing: 0.5 },
+  h2: { fontSize: FONT_SIZES.xl, fontWeight: FONT_WEIGHTS.bold },
+  body: { fontSize: FONT_SIZES.md, fontWeight: FONT_WEIGHTS.regular }
 };


### PR DESCRIPTION
## Summary
- define reusable font size/weight constants in `src/theme/typography.ts`
- add spacing scale in `src/theme/spacing.ts`
- refactor screens and components to consume new design tokens
- document typography and spacing usage for contributors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeca4c797c832ea3525107461bf913