### PR TITLE
Enable Android testing with Expo Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@
 ## Requirements
 
 * Node 18–20 (avoid Node 22)
-* Android device (Expo Dev Client recommended)
+* Android device with Expo Go installed
 
 ## Install \& Run
 
 npm install
-npx expo install expo-av expo-file-system expo-sensors expo-speech expo-dev-client   
-'@react-navigation/native '@react-navigation/native-stack react-native-screens   
+npx expo install expo-av expo-file-system expo-sensors expo-speech \
+'@react-navigation/native' '@react-navigation/native-stack' react-native-screens \
 react-native-safe-area-context react-native-gesture-handler react-native-reanimated
 
 # (Optional voice)
 
 npm i @react-native-voice/voice
 
-# Start (Dev Client preferred)
+# Start (Expo Go)
 
-npx expo start --dev-client --tunnel
+npx expo start --tunnel
 
 ## Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "typescript": "~5.8.3"
       },
       "engines": {
-        "node": ">=18 <=20"
+        "node": ">=18"
       }
     },
     "node_modules/@0no-co/graphql.web": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --dev-client",
+    "android": "expo start --android --tunnel",
     "web": "expo start --web",
     "devclient": "expo start --dev-client --tunnel",
     "test": "node --test --import tsx tests/signal.test.ts"
@@ -48,7 +48,7 @@
     "typescript": "~5.8.3"
   },
   "engines": {
-    "node": ">=18 <=20"
+    "node": ">=18"
   },
   "expo": {
     "plugins": [


### PR DESCRIPTION
## Summary
- update README to document Android testing via Expo Go
- run Android script through Expo Go instead of dev client
- widen Node engine range to support Node 22

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed84143bc832eaac78d0830b78fac