### PR TITLE
chore: add spiritual theme overlay

### DIFF
--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -14,6 +14,8 @@ export const colors = {
   accent: '#8C52FF',
   // ethereal teal
   accent2: '#00FFD0',
+  // luminous tohunga turquoise
+  tohunga: '#00F6FF',
   // subtle violet overlay
   overlay: 'rgba(140,82,255,0.08)',
   // deep red

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -14,35 +14,30 @@ export const navTheme: NavTheme = {
     card: colors.card,
     text: colors.text,
     border: colors.line,
-    primary: colors.accent,
+    primary: colors.tohunga,
     notification: colors.neon,
   },
 };
 
-import { ImageBackground, StyleSheet, View, Animated, Easing } from 'react-native';
+import { ImageBackground, StyleSheet, View } from 'react-native';
+import ParticleField from '../../components/fx/ParticleField';
+import NoiseOverlay from '../../components/fx/NoiseOverlay';
 
 export function ThemeProvider({ children }: PropsWithChildren) {
-
   return (
-    <View style={{ flex: 1 }}>
-      {/* Gradient background for astral/spiritual effect */}
-      <View style={styles.gradientBg}>
-        {children}
-      </View>
-    </View>
+    <ImageBackground
+      source={require('../../assets/bg-astral.png')}
+      style={styles.bg}
+      resizeMode="cover"
+    >
+      <ParticleField />
+      <NoiseOverlay />
+      <View style={[StyleSheet.absoluteFill, { backgroundColor: colors.tohunga, opacity: 0.05 }]} />
+      {children}
+    </ImageBackground>
   );
 }
 
 const styles = StyleSheet.create({
-  gradientBg: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    zIndex: -1,
-    backgroundColor: '#2C1B0F', // lighter brown for better contrast
-  },
-  bg: { flex: 1, width: '100%', height: '100%', justifyContent: 'center', backgroundColor: '#2C1B0F' },
-  overlay: { flex: 1, opacity: 0.08, justifyContent: 'center' }, // lower overlay opacity for brightness
+  bg: { flex: 1, width: '100%', height: '100%' },
 });


### PR DESCRIPTION
## Summary
- add luminous Tohunga turquoise accent to theme
- overlay cosmic particle and noise background for an immersive vibe
- use astral background image across the app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aecd8a6f00832e8e108be78aa4984c