### PR TITLE
Fix TypeScript errors and optimize Android audio settings

### DIFF
--- a/components/evp/SpectrogramPreview.tsx
+++ b/components/evp/SpectrogramPreview.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import { View } from 'react-native';
 import { Svg, Rect } from 'react-native-svg';
 
 interface SpectrogramPreviewProps {
-  audioBuffer: number[];
+  audioBuffer?: number[];
 }
 
-export default function SpectrogramPreview({ audioBuffer }: SpectrogramPreviewProps) {
+export default function SpectrogramPreview({ audioBuffer = [] }: SpectrogramPreviewProps) {
   const width = 300;
   const height = 80;
-  const barWidth = width / audioBuffer.length;
+  const barWidth = audioBuffer.length > 0 ? width / audioBuffer.length : width;
 
   return (
     <Svg height={height} width={width} style={{ backgroundColor: '#222' }}>

--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -20,7 +20,14 @@ export default function Logbook({ navigation }: any) {
         keyExtractor={item => item.id}
         renderItem={({ item }) => (
           <TouchableOpacity onPress={() => navigation?.navigate?.('SessionDetail', { session: item })}>
-            <SessionItem session={item} />
+            <SessionItem
+              session={item}
+              onView={() => navigation?.navigate?.('SessionDetail', { session: item })}
+              onDelete={async () => {
+                await SessionStore.delete(item.id);
+                setSessions(prev => prev.filter(s => s.id !== item.id));
+              }}
+            />
           </TouchableOpacity>
         )}
         contentContainerStyle={{ padding: 16 }}

--- a/screens/SpiritBoard.tsx
+++ b/screens/SpiritBoard.tsx
@@ -15,10 +15,10 @@ export default function SpiritBoard() {
 
   // Use entropy from sensors for pointer movement
   useEffect(() => {
-    const interval = setInterval(() => {
+    const interval = setInterval(async () => {
+      const e = await getEntropy();
       setPointer((p) => {
         // Use entropy to bias movement
-        const e = getEntropy();
         let row = p.row + (e > 0.5 ? 1 : -1) * (e > 0.7 ? 1 : 0);
         let col = p.col + (e < 0.5 ? 1 : -1) * (e < 0.3 ? 1 : 0);
         row = Math.max(0, Math.min(LETTERS.length - 1, row));

--- a/services/rng/Entropy.ts
+++ b/services/rng/Entropy.ts
@@ -13,11 +13,11 @@ export default async function getEntropy() {
       const recordingOptions = {
         android: {
           extension: '.m4a',
-          outputFormat: 2, // Default MPEG_4
-          audioEncoder: 3, // Default AAC
-          sampleRate: 44100,
-          numberOfChannels: 2,
-          bitRate: 128000,
+          outputFormat: 2, // MPEG_4
+          audioEncoder: 3, // AAC
+          sampleRate: 16000,
+          numberOfChannels: 1,
+          bitRate: 64000,
         },
         ios: {
           extension: '.caf',


### PR DESCRIPTION
## Summary
- Make spectrogram preview audio buffer optional
- Pass session callbacks in logbook entries
- Resolve async entropy usage on spirit board
- Use lighter recording options on Android

## Testing
- `npm test`
- `npx tsc --noEmit && echo tsc-ok`


------
https://chatgpt.com/codex/tasks/task_e_68aef6b91eb0832e8db1d76fd633e990