### PR TITLE
Use JSZip to export sessions as zip

### DIFF
--- a/services/export/zipSession.ts
+++ b/services/export/zipSession.ts
@@ -2,23 +2,38 @@
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import * as Crypto from 'expo-crypto';
+import JSZip from 'jszip';
 
-// Minimal zip: just copy JSON and media to a folder, return folder path (simulate zip)
+// Create a real zip archive containing session.json and any media assets
 export default async function zipSession(session: any) {
-  const tmpDir = FileSystem.cacheDirectory + 'session_' + (await Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA1, session.id)) + '/';
+  const tmpDir = FileSystem.cacheDirectory +
+    'session_' +
+    (await Crypto.digestStringAsync(
+      Crypto.CryptoDigestAlgorithm.SHA1,
+      session.id
+    )) +
+    '/';
+
   await FileSystem.makeDirectoryAsync(tmpDir, { intermediates: true });
-  // Write session JSON
-  const jsonPath = tmpDir + 'session.json';
-  await FileSystem.writeAsStringAsync(jsonPath, JSON.stringify(session, null, 2));
-  // Copy media
-  let mediaPath = null;
+  const zipFilePath = tmpDir + 'session.zip';
+
+  const zip = new JSZip();
+  zip.file('session.json', JSON.stringify(session, null, 2));
+
   if (session.uri) {
     const ext = session.uri.split('.').pop();
-    mediaPath = tmpDir + 'audio.' + ext;
-    await FileSystem.copyAsync({ from: session.uri, to: mediaPath });
+    const mediaContent = await FileSystem.readAsStringAsync(session.uri, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+    zip.file(`audio.${ext}`, mediaContent, { base64: true });
   }
-  // Simulate zip: return folder path (could use a real zip lib)
-  return tmpDir;
+
+  const zipContent = await zip.generateAsync({ type: 'base64' });
+  await FileSystem.writeAsStringAsync(zipFilePath, zipContent, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+
+  return zipFilePath;
 }
 
 export async function shareSessionZip(session: any) {


### PR DESCRIPTION
## Summary
- use JSZip to package session JSON and audio into a `session.zip`
- share exported session via actual zip file path

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef8dce950832eb09d9b64692d4489