### PR TITLE
refactor: centralize theme usage across screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { ThemeProvider } from './src/theme/theme';
+import { ThemeProvider as BackgroundProvider } from './src/theme/theme';
+import { ThemeProvider } from './theme';
 import EsmeraProvider from './services/tts/EsmeraProvider';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -82,19 +83,21 @@ export default function App() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <ThemeProvider>
-        <EsmeraProvider>
-          <NavigationContainer>
-            {showOnboarding ? (
-              <Stack.Navigator initialRouteName="OnboardingIntro" screenOptions={{ headerShown: false }}>
-                <Stack.Screen name="OnboardingIntro" component={OnboardingIntro} />
-                <Stack.Screen name="OnboardingHowTo" component={OnboardingHowTo} />
-                <Stack.Screen name="OnboardingPrivacy" component={OnboardingPrivacy} />
-              </Stack.Navigator>
-            ) : (
-              <TestNavigator />
-            )}
-          </NavigationContainer>
-        </EsmeraProvider>
+        <BackgroundProvider>
+          <EsmeraProvider>
+            <NavigationContainer>
+              {showOnboarding ? (
+                <Stack.Navigator initialRouteName="OnboardingIntro" screenOptions={{ headerShown: false }}>
+                  <Stack.Screen name="OnboardingIntro" component={OnboardingIntro} />
+                  <Stack.Screen name="OnboardingHowTo" component={OnboardingHowTo} />
+                  <Stack.Screen name="OnboardingPrivacy" component={OnboardingPrivacy} />
+                </Stack.Navigator>
+              ) : (
+                <TestNavigator />
+              )}
+            </NavigationContainer>
+          </EsmeraProvider>
+        </BackgroundProvider>
       </ThemeProvider>
     </GestureHandlerRootView>
   );

--- a/screens/EVPRecorder.tsx
+++ b/screens/EVPRecorder.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { View, Text, Button, StyleSheet, Alert } from 'react-native';
+import { useTheme } from '../theme';
 import * as Recorder from '../services/audio/Recorder';
 import SessionStore from '../services/sessions/SessionStore';
 import SpectrogramPreview from '../components/evp/SpectrogramPreview';
 import { detectAnomalies } from '../src/core/anomaly/detector';
 
 export default function EVPRecorder() {
+  const { theme } = useTheme();
   const [recording, setRecording] = useState(false);
   const [uri, setUri] = useState<string | null>(null);
   const [markers, setMarkers] = useState<number[]>([]);
@@ -55,17 +57,17 @@ export default function EVPRecorder() {
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>EVP Recorder</Text>
+    <View style={[styles.container, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[styles.title, { color: theme.colors.text }]}>EVP Recorder</Text>
       <View style={styles.status}>
-        <Text>Status: {recording ? 'Recording...' : uri ? 'Stopped' : 'Idle'}</Text>
-        {uri && <Text>File: {uri}</Text>}
-        {markers.length > 0 && <Text>Markers: {markers.join(', ')}</Text>}
+        <Text style={{ color: theme.colors.text }}>Status: {recording ? 'Recording...' : uri ? 'Stopped' : 'Idle'}</Text>
+        {uri && <Text style={{ color: theme.colors.text }}>File: {uri}</Text>}
+        {markers.length > 0 && <Text style={{ color: theme.colors.text }}>Markers: {markers.join(', ')}</Text>}
         {anomalies.length > 0 && (
           <View style={{ marginTop: 8 }}>
-            <Text>Anomalies Detected:</Text>
+            <Text style={{ color: theme.colors.text }}>Anomalies Detected:</Text>
             {anomalies.map((a, i) => (
-              <Text key={i}>{`Time: ${a.time}, Freq: ${Math.round(a.freq)}Hz, Confidence: ${Math.round(a.confidence * 100)}%`}</Text>
+              <Text key={i} style={{ color: theme.colors.text }}>{`Time: ${a.time}, Freq: ${Math.round(a.freq)}Hz, Confidence: ${Math.round(a.confidence * 100)}%`}</Text>
             ))}
           </View>
         )}
@@ -73,13 +75,13 @@ export default function EVPRecorder() {
       <SpectrogramPreview />
       <View style={styles.buttons}>
         {!recording ? (
-          <Button title="Start Recording" onPress={start} />
+          <Button title="Start Recording" onPress={start} color={theme.colors.accent} />
         ) : (
-          <Button title="Stop Recording" onPress={stop} />
+          <Button title="Stop Recording" onPress={stop} color={theme.colors.accent} />
         )}
-        {recording && <Button title="Mark Anomaly" onPress={mark} />}
-        {uri && <Button title="Save Session" onPress={saveSession} />}
-        {uri && <Button title="Play Recording" onPress={handlePlay} />}
+        {recording && <Button title="Mark Anomaly" onPress={mark} color={theme.colors.accent} />}
+        {uri && <Button title="Save Session" onPress={saveSession} color={theme.colors.accent} />}
+        {uri && <Button title="Play Recording" onPress={handlePlay} color={theme.colors.accent} />}
       </View>
     </View>
   );

--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme } from '../theme';
 import SessionStore from '../services/sessions/SessionStore';
 import SessionItem from '../components/logbook/SessionItem';
 
 export default function Logbook({ navigation }: any) {
+  const { theme } = useTheme();
   const [sessions, setSessions] = useState<any[]>([]);
   useEffect(() => {
     (async () => {
@@ -13,8 +15,8 @@ export default function Logbook({ navigation }: any) {
   }, []);
 
   return (
-    <View style={styles.flex}>
-      <Text style={styles.title}>Logbook</Text>
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[styles.title, { color: theme.colors.text }]}>Logbook</Text>
       <FlatList
         data={sessions}
         keyExtractor={item => item.id}
@@ -24,14 +26,14 @@ export default function Logbook({ navigation }: any) {
           </TouchableOpacity>
         )}
         contentContainerStyle={{ padding: 16 }}
-        ListEmptyComponent={<Text style={styles.empty}>No sessions yet.</Text>}
+        ListEmptyComponent={<Text style={[styles.empty, { color: theme.colors.text, opacity: 0.6 }]}>No sessions yet.</Text>}
       />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', margin: 16 },
-  empty: { color: '#888', textAlign: 'center', marginTop: 40 },
+  flex: { flex: 1 },
+  title: { fontSize: 28, fontWeight: '800', margin: 16 },
+  empty: { textAlign: 'center', marginTop: 40 },
 });

--- a/screens/Onboarding/HowTo.tsx
+++ b/screens/Onboarding/HowTo.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { useTheme } from '../../theme';
 
 export default function OnboardingHowTo({ navigation }: any) {
+  const { theme } = useTheme();
   return (
-    <View style={styles.flex}>
-      <Text style={styles.title}>How to Use Ech0Void</Text>
-      <Text style={styles.body}>
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[styles.title, { color: theme.colors.text }]}>How to Use Ech0Void</Text>
+      <Text style={[styles.body, { color: theme.colors.text, opacity: 0.8 }]}>
         1. Begin a Live ITC session to record and mark anomalies.\n
         2. Review your sessions in the Logbook.\n
         3. Export, share, or analyze your results.\n
@@ -18,8 +20,8 @@ export default function OnboardingHowTo({ navigation }: any) {
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+  title: { fontSize: 28, fontWeight: '800', marginBottom: 24 },
+  body: { fontSize: 16, textAlign: 'center', marginBottom: 32 },
   btn: { minWidth: 160 },
 });

--- a/screens/Onboarding/Intro.tsx
+++ b/screens/Onboarding/Intro.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { useTheme } from '../../theme';
 
 export default function OnboardingIntro({ navigation }: any) {
+  const { theme } = useTheme();
   return (
-    <View style={styles.flex}>
-      <Text style={styles.title}>Welcome to Ech0Void</Text>
-      <Text style={styles.body}>
-        Ech0Void is a modern ITC toolkit for exploring anomalous audio, spirit communication, and creative consciousness. 
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[styles.title, { color: theme.colors.text }]}>Welcome to Ech0Void</Text>
+      <Text style={[styles.body, { color: theme.colors.text, opacity: 0.8 }]}>
+        Ech0Void is a modern ITC toolkit for exploring anomalous audio, spirit communication, and creative consciousness.
         Record, analyze, and share your sessions with a beautiful, intuitive interface.
       </Text>
       <EVoidButton label="How to Use" onPress={() => navigation?.navigate?.('OnboardingHowTo')} style={styles.btn} />
@@ -16,8 +18,8 @@ export default function OnboardingIntro({ navigation }: any) {
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+  title: { fontSize: 28, fontWeight: '800', marginBottom: 24 },
+  body: { fontSize: 16, textAlign: 'center', marginBottom: 32 },
   btn: { minWidth: 160 },
 });

--- a/screens/Onboarding/Privacy.tsx
+++ b/screens/Onboarding/Privacy.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useTheme } from '../../theme';
 
 export default function OnboardingPrivacy({ navigation }: any) {
+  const { theme } = useTheme();
   return (
-    <View style={styles.flex}>
-      <Text style={styles.title}>Privacy & Permissions</Text>
-      <Text style={styles.body}>
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[styles.title, { color: theme.colors.text }]}>Privacy & Permissions</Text>
+      <Text style={[styles.body, { color: theme.colors.text, opacity: 0.8 }]}>
         Ech0Void only requests permissions needed for audio recording and file access.{"\n"}
         Your data is stored locally and never shared without your consent.{"\n"}
         You can export or delete your sessions at any time from the Logbook.
@@ -19,14 +21,14 @@ export default function OnboardingPrivacy({ navigation }: any) {
       <EVoidButton label="Skip Onboarding" onPress={async () => {
         await AsyncStorage.setItem('onboarded', '1');
         navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
-      }} style={[styles.btn, { marginTop: 16, backgroundColor: '#333' }]} />
+      }} style={[styles.btn, { marginTop: 16, backgroundColor: theme.colors.surface }]} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+  title: { fontSize: 28, fontWeight: '800', marginBottom: 24 },
+  body: { fontSize: 16, textAlign: 'center', marginBottom: 32 },
   btn: { minWidth: 160 },
 });

--- a/screens/SigilMaker.tsx
+++ b/screens/SigilMaker.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
+import { useTheme } from '../theme';
 import buildSigil from '../services/sigil/buildSigil';
 
 export default function SigilMaker() {
+  const { theme } = useTheme();
   const [phrase, setPhrase] = useState('');
   const [sigilPath, setSigilPath] = useState('');
 
@@ -12,20 +14,21 @@ export default function SigilMaker() {
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Sigil Maker</Text>
+    <View style={[styles.container, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[styles.title, { color: theme.colors.text }]}>Sigil Maker</Text>
       <TextInput
-        style={styles.input}
+        style={[styles.input, { borderColor: theme.colors.text, color: theme.colors.text }]}
         placeholder="Enter a phrase"
+        placeholderTextColor={theme.colors.text}
         value={phrase}
         onChangeText={setPhrase}
       />
       <TouchableOpacity onPress={handleGenerate}>
-        <Text style={styles.button}>Generate</Text>
+        <Text style={[styles.button, { color: theme.colors.accent }]}>Generate</Text>
       </TouchableOpacity>
       {sigilPath ? (
         <Svg height="100" width="100" viewBox="0 0 100 100">
-          <Path d={sigilPath} stroke="black" fill="none" />
+          <Path d={sigilPath} stroke={theme.colors.text} fill="none" />
         </Svg>
       ) : null}
     </View>
@@ -35,6 +38,6 @@ export default function SigilMaker() {
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
   title: { fontSize: 24, marginBottom: 16 },
-  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, width: '100%', marginBottom: 16 },
-  button: { color: 'blue', marginBottom: 16 },
+  input: { borderWidth: 1, padding: 8, width: '100%', marginBottom: 16 },
+  button: { marginBottom: 16 },
 });

--- a/screens/SpiritBoard.tsx
+++ b/screens/SpiritBoard.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../theme';
 import getEntropy from '../services/rng/Entropy';
 
 const LETTERS = [
@@ -11,6 +12,7 @@ const LETTERS = [
 ];
 
 export default function SpiritBoard() {
+  const { theme } = useTheme();
   const [pointer, setPointer] = useState({ row: 1, col: 3 });
 
   // Use entropy from sensors for pointer movement
@@ -30,34 +32,41 @@ export default function SpiritBoard() {
   }, []);
 
   return (
-    <View style={styles.flex}>
-      <Text style={styles.title}>Spirit Board</Text>
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[styles.title, { color: theme.colors.text }]}>Spirit Board</Text>
       <View style={styles.grid}>
         {LETTERS.map((row, r) => (
           <View key={r} style={styles.row}>
             {row.map((ch, c) => (
               <View
                 key={ch}
-                style={[styles.cell, pointer.row === r && pointer.col === c && styles.pointer]}
+                style={[
+                  styles.cell,
+                  { backgroundColor: theme.colors.surface },
+                  pointer.row === r && pointer.col === c && {
+                    backgroundColor: theme.colors.accent,
+                    borderWidth: 2,
+                    borderColor: theme.colors.text,
+                  },
+                ]}
               >
-                <Text style={styles.letter}>{ch}</Text>
+                <Text style={[styles.letter, { color: theme.colors.text }]}>{ch}</Text>
               </View>
             ))}
           </View>
         ))}
       </View>
-      <Text style={styles.tip}>Pointer uses sensor entropy for movement</Text>
+      <Text style={[styles.tip, { color: theme.colors.text, opacity: 0.7 }]}>Pointer uses sensor entropy for movement</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 28, fontWeight: '800', marginBottom: 24 },
   grid: { marginBottom: 32 },
   row: { flexDirection: 'row' },
-  cell: { width: 44, height: 44, borderRadius: 22, backgroundColor: '#222', margin: 6, alignItems: 'center', justifyContent: 'center' },
-  pointer: { backgroundColor: '#00E0FF', borderWidth: 2, borderColor: '#fff' },
-  letter: { color: '#fff', fontSize: 22, fontWeight: '700' },
-  tip: { color: '#aaa', fontSize: 13, marginTop: 12 },
+  cell: { width: 44, height: 44, borderRadius: 22, margin: 6, alignItems: 'center', justifyContent: 'center' },
+  letter: { fontSize: 22, fontWeight: '700' },
+  tip: { fontSize: 13, marginTop: 12 },
 });

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -5,6 +5,7 @@ export const themeColors = {
 import React, { PropsWithChildren } from 'react';
 import { DefaultTheme, Theme as NavTheme } from '@react-navigation/native';
 import { colors } from './colors';
+import { useTheme } from '../../theme';
 
 export const navTheme: NavTheme = {
   ...DefaultTheme,
@@ -19,14 +20,14 @@ export const navTheme: NavTheme = {
   },
 };
 
-import { ImageBackground, StyleSheet, View, Animated, Easing } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 export function ThemeProvider({ children }: PropsWithChildren) {
-
+  const { theme } = useTheme();
   return (
     <View style={{ flex: 1 }}>
       {/* Gradient background for astral/spiritual effect */}
-      <View style={styles.gradientBg}>
+      <View style={[styles.gradientBg, { backgroundColor: theme.colors.bg }]}>
         {children}
       </View>
     </View>
@@ -41,8 +42,5 @@ const styles = StyleSheet.create({
     right: 0,
     bottom: 0,
     zIndex: -1,
-    backgroundColor: '#2C1B0F', // lighter brown for better contrast
   },
-  bg: { flex: 1, width: '100%', height: '100%', justifyContent: 'center', backgroundColor: '#2C1B0F' },
-  overlay: { flex: 1, opacity: 0.08, justifyContent: 'center' }, // lower overlay opacity for brightness
 });


### PR DESCRIPTION
## Summary
- provide ThemeProvider context to the app and apply a background provider
- replace hard-coded colors in logbook, recorder, onboarding, and spirit board screens with theme.colors
- use theme in gradient ThemeProvider so screens access consistent colors

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aef9296a68832e86caec6a7cc16342