### PR TITLE
refactor: unify screen layout

### DIFF
--- a/screens/EVPRecorder.tsx
+++ b/screens/EVPRecorder.tsx
@@ -4,6 +4,7 @@ import * as Recorder from '../services/audio/Recorder';
 import SessionStore from '../services/sessions/SessionStore';
 import SpectrogramPreview from '../components/evp/SpectrogramPreview';
 import { detectAnomalies } from '../src/core/anomaly/detector';
+import Screen from './_layout/Screen';
 
 export default function EVPRecorder() {
   const [recording, setRecording] = useState(false);
@@ -55,7 +56,7 @@ export default function EVPRecorder() {
   };
 
   return (
-    <View style={styles.container}>
+    <Screen style={styles.container}>
       <Text style={styles.title}>EVP Recorder</Text>
       <View style={styles.status}>
         <Text>Status: {recording ? 'Recording...' : uri ? 'Stopped' : 'Idle'}</Text>
@@ -81,7 +82,7 @@ export default function EVPRecorder() {
         {uri && <Button title="Save Session" onPress={saveSession} />}
         {uri && <Button title="Play Recording" onPress={handlePlay} />}
       </View>
-    </View>
+    </Screen>
   );
 }
 

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -2,8 +2,8 @@
 
 import { View, Text, StyleSheet, Image } from 'react-native';
 import { useTheme } from '../theme';
-import ParticleField from '../components/fx/ParticleField';
 import EVoidButton from '../components/ui/EVoidButton';
+import Screen from './_layout/Screen';
 
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../src/navigation/AppNavigator';
@@ -13,17 +13,16 @@ export default function Home() {
   const { theme } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList, 'Home'>>();
   return (
-    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
-      <ParticleField />
+    <Screen style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
       <View style={styles.center}>
         <Image source={require('../assets/logo.svg')} style={{ width: 96, height: 96, marginBottom: 16 }} />
         <Text style={[styles.title, { color: theme.colors.text }]}>Ech0Void</Text>
         <Text style={[styles.subtitle, { color: theme.colors.accent }]}>where echos become answers</Text>
-  <EVoidButton label="Begin Transmission" onPress={() => navigation.navigate('Transmission')} style={styles.btn} />
-  <EVoidButton label="Settings" onPress={() => navigation.navigate('Settings')} style={styles.btn} />
-  <EVoidButton label="AR Mode" onPress={() => navigation.navigate('ARMode')} style={styles.btn} />
+        <EVoidButton label="Begin Transmission" onPress={() => navigation.navigate('Transmission')} style={styles.btn} />
+        <EVoidButton label="Settings" onPress={() => navigation.navigate('Settings')} style={styles.btn} />
+        <EVoidButton label="AR Mode" onPress={() => navigation.navigate('ARMode')} style={styles.btn} />
       </View>
-    </View>
+    </Screen>
   );
 }
 

--- a/screens/LiveITC.tsx
+++ b/screens/LiveITC.tsx
@@ -3,7 +3,7 @@ import { Magnetometer, Accelerometer } from 'expo-sensors';
 import { createEngine, PRESETS } from '../src/core/audio/evpEngine';
 import { WORD_BANK } from '../src/core/audio/wordBank';
 import LiveChain from '../services/audio/LiveChain';
-import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../theme';
 import VU from '../components/controls/VU';
 import Knob from '../components/controls/Knob';
@@ -12,9 +12,9 @@ import Toggle from '../components/controls/Toggle';
 import Chip from '../components/controls/Chip';
 import XYPad from '../components/controls/XYPad';
 import AudioReactiveBars from '../components/fx/AudioReactiveBars';
-import NoiseOverlay from '../components/fx/NoiseOverlay';
 import Timer from '../components/controls/Timer';
 import EVoidButton from '../components/ui/EVoidButton';
+import Screen from './_layout/Screen';
 
 
 function LiveITC() {
@@ -105,8 +105,7 @@ function LiveITC() {
   };
 
   return (
-    <SafeAreaView style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
-      <NoiseOverlay />
+    <Screen style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
       <View style={styles.header}>
         <Text style={[styles.title, { color: theme.colors.text }]}>Live ITC</Text>
         <Timer ms={timer} />
@@ -137,7 +136,7 @@ function LiveITC() {
         <EVoidSlider value={gain} onChange={setGain} min={0} max={1} label="Mix" format="" />
         <XYPad x={x} y={y} onChange={(nx, ny) => { setX(nx); setY(ny); }} label="Mod" />
       </View>
-    </SafeAreaView>
+    </Screen>
   );
 }
 

--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import { Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
 import SessionStore from '../services/sessions/SessionStore';
 import SessionItem from '../components/logbook/SessionItem';
+import Screen from './_layout/Screen';
 
 export default function Logbook({ navigation }: any) {
   const [sessions, setSessions] = useState<any[]>([]);
@@ -13,7 +14,7 @@ export default function Logbook({ navigation }: any) {
   }, []);
 
   return (
-    <View style={styles.flex}>
+    <Screen style={styles.flex}>
       <Text style={styles.title}>Logbook</Text>
       <FlatList
         data={sessions}
@@ -26,7 +27,7 @@ export default function Logbook({ navigation }: any) {
         contentContainerStyle={{ padding: 16 }}
         ListEmptyComponent={<Text style={styles.empty}>No sessions yet.</Text>}
       />
-    </View>
+    </Screen>
   );
 }
 

--- a/screens/Onboarding/HowTo.tsx
+++ b/screens/Onboarding/HowTo.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import Screen from '../_layout/Screen';
 
 export default function OnboardingHowTo({ navigation }: any) {
   return (
-    <View style={styles.flex}>
+    <Screen style={styles.flex}>
       <Text style={styles.title}>How to Use Ech0Void</Text>
       <Text style={styles.body}>
         1. Begin a Live ITC session to record and mark anomalies.\n
@@ -13,7 +14,7 @@ export default function OnboardingHowTo({ navigation }: any) {
         4. Explore advanced features in Settings.
       </Text>
       <EVoidButton label="Privacy & Permissions" onPress={() => navigation?.navigate?.('OnboardingPrivacy')} style={styles.btn} />
-    </View>
+    </Screen>
   );
 }
 

--- a/screens/Onboarding/Intro.tsx
+++ b/screens/Onboarding/Intro.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import Screen from '../_layout/Screen';
 
 export default function OnboardingIntro({ navigation }: any) {
   return (
-    <View style={styles.flex}>
+    <Screen style={styles.flex}>
       <Text style={styles.title}>Welcome to Ech0Void</Text>
       <Text style={styles.body}>
         Ech0Void is a modern ITC toolkit for exploring anomalous audio, spirit communication, and creative consciousness. 
         Record, analyze, and share your sessions with a beautiful, intuitive interface.
       </Text>
       <EVoidButton label="How to Use" onPress={() => navigation?.navigate?.('OnboardingHowTo')} style={styles.btn} />
-    </View>
+    </Screen>
   );
 }
 

--- a/screens/Onboarding/Privacy.tsx
+++ b/screens/Onboarding/Privacy.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import Screen from '../_layout/Screen';
 
 export default function OnboardingPrivacy({ navigation }: any) {
   return (
-    <View style={styles.flex}>
+    <Screen style={styles.flex}>
       <Text style={styles.title}>Privacy & Permissions</Text>
       <Text style={styles.body}>
         Ech0Void only requests permissions needed for audio recording and file access.{"\n"}
@@ -20,7 +21,7 @@ export default function OnboardingPrivacy({ navigation }: any) {
         await AsyncStorage.setItem('onboarded', '1');
         navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
       }} style={[styles.btn, { marginTop: 16, backgroundColor: '#333' }]} />
-    </View>
+    </Screen>
   );
 }
 

--- a/screens/Settings.tsx
+++ b/screens/Settings.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 import { useTheme, themes, ThemeName } from '../theme';
 import Chip from '../components/controls/Chip';
+import Screen from './_layout/Screen';
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
   return (
-    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
+    <Screen style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
       <Text style={[styles.title, { color: theme.colors.text }]}>Settings</Text>
       <Text style={[styles.label, { color: theme.colors.text }]}>Theme</Text>
       <Chip
@@ -17,7 +18,7 @@ export default function Settings() {
       <Text style={[styles.label, { color: theme.colors.text }]}>Audio FX (coming soon)</Text>
       <Text style={[styles.label, { color: theme.colors.text }]}>Performance (coming soon)</Text>
       <Text style={[styles.label, { color: theme.colors.text }]}>Privacy (coming soon)</Text>
-    </View>
+    </Screen>
   );
 }
 

--- a/screens/SigilMaker.tsx
+++ b/screens/SigilMaker.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 import buildSigil from '../services/sigil/buildSigil';
+import Screen from './_layout/Screen';
 
 export default function SigilMaker() {
   const [phrase, setPhrase] = useState('');
@@ -12,7 +13,7 @@ export default function SigilMaker() {
   };
 
   return (
-    <View style={styles.container}>
+    <Screen style={styles.container}>
       <Text style={styles.title}>Sigil Maker</Text>
       <TextInput
         style={styles.input}
@@ -28,7 +29,7 @@ export default function SigilMaker() {
           <Path d={sigilPath} stroke="black" fill="none" />
         </Svg>
       ) : null}
-    </View>
+    </Screen>
   );
 }
 

--- a/screens/SpiritBoard.tsx
+++ b/screens/SpiritBoard.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import getEntropy from '../services/rng/Entropy';
+import Screen from './_layout/Screen';
 
 const LETTERS = [
   ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
@@ -30,7 +31,7 @@ export default function SpiritBoard() {
   }, []);
 
   return (
-    <View style={styles.flex}>
+    <Screen style={styles.flex}>
       <Text style={styles.title}>Spirit Board</Text>
       <View style={styles.grid}>
         {LETTERS.map((row, r) => (
@@ -47,7 +48,7 @@ export default function SpiritBoard() {
         ))}
       </View>
       <Text style={styles.tip}>Pointer uses sensor entropy for movement</Text>
-    </View>
+    </Screen>
   );
 }
 

--- a/src/screens/ARModeScreen.tsx
+++ b/src/screens/ARModeScreen.tsx
@@ -6,6 +6,7 @@ import { GLView } from 'expo-gl';
 import { Renderer } from 'expo-three';
 import * as THREE from 'three';
 import { colors } from '../theme/colors';
+import Screen from './_layout/Screen';
 
 const { width, height } = Dimensions.get('window');
 
@@ -63,7 +64,7 @@ export default function ARModeScreen({ navigation }: any) {
   };
 
   return (
-    <View style={{ flex: 1 }}>
+    <Screen style={{ flex: 1 }}>
       {hasPermission && (
         <ExpoCamera ref={cameraRef} style={StyleSheet.absoluteFill} type={type} />
       )}
@@ -78,7 +79,7 @@ export default function ARModeScreen({ navigation }: any) {
         <Text style={styles.p}>Light: {light ? light.toFixed(2) : 'n/a'} lux</Text>
         <Text style={styles.p}>(3D compass overlays camera, reacts to sensors)</Text>
       </View>
-    </View>
+    </Screen>
   );
 }
 

--- a/src/screens/ARScreen.tsx
+++ b/src/screens/ARScreen.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
-import { View, Text, Pressable } from 'react-native';
+import { Text, Pressable } from 'react-native';
 import { colors } from '../theme/colors';
+import Screen from './_layout/Screen';
+
 export default function ARScreen(){
   const [active,setActive] = useState(false);
   return (
-  <View style={{flex:1, backgroundColor:colors.bg, alignItems:'center', justifyContent:'center'}}>
-  <Text style={{color:colors.text, marginBottom:20}}>AR Mode {active?'Active':'Idle'}</Text>
-  <Pressable onPress={()=>setActive(a=>!a)} style={{padding:12,borderWidth:1,borderColor:colors.neon}}>
-  <Text style={{color:colors.neon}}>{active?'Stop':'Start'} AR</Text>
+    <Screen style={{flex:1, backgroundColor:colors.bg, alignItems:'center', justifyContent:'center'}}>
+      <Text style={{color:colors.text, marginBottom:20}}>AR Mode {active?'Active':'Idle'}</Text>
+      <Pressable onPress={()=>setActive(a=>!a)} style={{padding:12,borderWidth:1,borderColor:colors.neon}}>
+        <Text style={{color:colors.neon}}>{active?'Stop':'Start'} AR</Text>
       </Pressable>
-    </View>
+    </Screen>
   );
 }

--- a/src/screens/AnomaliesScreen.tsx
+++ b/src/screens/AnomaliesScreen.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { Text } from 'react-native';
 import { colors } from '../theme/colors';
+import Screen from './_layout/Screen';
+
 export default function AnomaliesScreen(){
   return (
-  <View style={{flex:1, backgroundColor:colors.bg, alignItems:'center', justifyContent:'center'}}>
-  <Text style={{color:colors.text}}>Anomalies (coming soon)</Text>
-    </View>
+    <Screen style={{ flex:1, backgroundColor:colors.bg, alignItems:'center', justifyContent:'center'}}>
+      <Text style={{color:colors.text}}>Anomalies (coming soon)</Text>
+    </Screen>
   );
 }

--- a/src/screens/FeedbackScreen.tsx
+++ b/src/screens/FeedbackScreen.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable } from 'react-native';
+import { Text, TextInput, Pressable } from 'react-native';
 import * as MailComposer from 'expo-mail-composer';
 import { colors } from '../theme/colors';
+import Screen from './_layout/Screen';
+
 export default function FeedbackScreen(){
   const [msg,setMsg] = useState('');
   function send() {
@@ -22,12 +24,12 @@ export default function FeedbackScreen(){
     }
   }
   return (
-  <View style={{flex:1, backgroundColor:colors.bg, padding:16}}>
-  <Text style={{color:colors.text, marginBottom:8}}>Feedback</Text>
-  <TextInput value={msg} onChangeText={setMsg} placeholder="share your thoughts" placeholderTextColor="#555" multiline style={{borderColor:colors.neon,borderWidth:1,color:colors.text,padding:8,minHeight:120}}/>
-  <Pressable onPress={send} style={{marginTop:12,padding:12,borderWidth:1,borderColor:colors.neon,alignSelf:'flex-start'}}>
-  <Text style={{color:colors.neon}}>Send</Text>
+    <Screen style={{flex:1, backgroundColor:colors.bg, padding:16}}>
+      <Text style={{color:colors.text, marginBottom:8}}>Feedback</Text>
+      <TextInput value={msg} onChangeText={setMsg} placeholder="share your thoughts" placeholderTextColor="#555" multiline style={{borderColor:colors.neon,borderWidth:1,color:colors.text,padding:8,minHeight:120}}/>
+      <Pressable onPress={send} style={{marginTop:12,padding:12,borderWidth:1,borderColor:colors.neon,alignSelf:'flex-start'}}>
+        <Text style={{color:colors.neon}}>Send</Text>
       </Pressable>
-    </View>
+    </Screen>
   );
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -6,6 +6,7 @@ import type { RootStackParamList } from '../navigation/AppNavigator';
 import UIButton from '../components/UIButton';
 import { colors } from '../theme/colors';
 import { hasNativeVoice, startListening } from '../voice/adapter';
+import Screen from './_layout/Screen';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
@@ -29,23 +30,25 @@ export default function HomeScreen({ navigation }: Props) {
   };
 
   return (
-    <LinearGradient
-      colors={[colors.bg, '#0A0A1C', colors.card]}
-      style={styles.flex}
-    >
-      <StatusBar barStyle="light-content" />
-      <View style={styles.container}>
+    <Screen>
+      <LinearGradient
+        colors={[colors.bg, '#0A0A1C', colors.card]}
+        style={styles.flex}
+      >
+        <StatusBar barStyle="light-content" />
+        <View style={styles.container}>
         <Text style={styles.title}>Ech0Void</Text>
         <Text style={styles.subtitle}>where echos become answers</Text>
 
         <UIButton label="Begin Transmission" onPress={onBegin} style={styles.btn} testID="btn-begin" />
-        <UIButton label="Settings" onPress={() => { console.log('[Home] Settings'); console.log('[HomeScreen] Navigating to Settings'); navigation.navigate('Settings'); }} style={styles.btn} testID="btn-settings" />
-        <UIButton label="AR Mode" onPress={() => { console.log('[Home] ARMode'); console.log('[HomeScreen] Navigating to ARMode'); navigation.navigate('ARMode'); }} style={styles.btn} testID="btn-ar" />
-      </View>
+          <UIButton label="Settings" onPress={() => { console.log('[Home] Settings'); console.log('[HomeScreen] Navigating to Settings'); navigation.navigate('Settings'); }} style={styles.btn} testID="btn-settings" />
+          <UIButton label="AR Mode" onPress={() => { console.log('[Home] ARMode'); console.log('[HomeScreen] Navigating to ARMode'); navigation.navigate('ARMode'); }} style={styles.btn} testID="btn-ar" />
+        </View>
 
-      {/* decorative neon ring that never intercepts touches */}
-      <View pointerEvents="none" style={styles.ring} />
-    </LinearGradient>
+        {/* decorative neon ring that never intercepts touches */}
+        <View pointerEvents="none" style={styles.ring} />
+      </LinearGradient>
+    </Screen>
   );
 }
 

--- a/src/screens/LogbookScreen.tsx
+++ b/src/screens/LogbookScreen.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { Text } from 'react-native';
 import { colors } from '../theme/colors';
+import Screen from './_layout/Screen';
+
 export default function LogbookScreen(){
   return (
-  <View style={{flex:1, backgroundColor:colors.bg, alignItems:'center', justifyContent:'center'}}>
-  <Text style={{color:colors.text}}>Logbook (coming soon)</Text>
-    </View>
+    <Screen style={{flex:1, backgroundColor:colors.bg, alignItems:'center', justifyContent:'center'}}>
+      <Text style={{color:colors.text}}>Logbook (coming soon)</Text>
+    </Screen>
   );
 }

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { View, Text, Pressable } from 'react-native';
+import { Text, Pressable } from 'react-native';
 import { colors } from '../theme/colors';
+import Screen from './_layout/Screen';
+
 export default function OnboardingScreen({onDone}:{onDone:()=>void}){
   return (
-  <View style={{flex:1, backgroundColor:colors.bg, justifyContent:'center', alignItems:'center', padding:24}}>
-  <Text style={{color:colors.text, marginBottom:20}}>Welcome to EchoVoid. Respect the wairua and proceed with care.</Text>
-  <Pressable onPress={onDone} style={{padding:12,borderWidth:1,borderColor:colors.neon}}>
-  <Text style={{color:colors.neon}}>Begin</Text>
+    <Screen style={{flex:1, backgroundColor:colors.bg, justifyContent:'center', alignItems:'center', padding:24}}>
+      <Text style={{color:colors.text, marginBottom:20}}>Welcome to EchoVoid. Respect the wairua and proceed with care.</Text>
+      <Pressable onPress={onDone} style={{padding:12,borderWidth:1,borderColor:colors.neon}}>
+        <Text style={{color:colors.neon}}>Begin</Text>
       </Pressable>
-    </View>
+    </Screen>
   );
 }

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import { View, Text, Pressable, ScrollView } from 'react-native';
 import { useSession } from '../context/SessionContext';
 import { colors } from '../theme/colors';
+import Screen from './_layout/Screen';
 import Meter from '../components/Meter';
 import Visualizer from '../components/Visualizer';
 import Toggle from '../components/Toggle';
@@ -25,7 +26,8 @@ export default function SessionScreen({navigation}:any){
   const onSpeak = ()=> speakEsmera(text || 'Welcome to EchoVoid.', !text);
 
   return (
-  <ScrollView style={{flex:1, backgroundColor:colors.bg}} contentContainerStyle={{padding:16, gap:16}}>
+    <Screen style={{flex:1, backgroundColor:colors.bg}}>
+      <ScrollView contentContainerStyle={{padding:16, gap:16}}>
       <Text style={{color:colors.text, fontSize:18}}>Mode</Text>
       <View style={{flexDirection:'row', flexWrap:'wrap'}}>
         {(['Standard','Mana','Reverse','DreamLink','Shadow','CallAndResponse'] as const).map(m =>
@@ -56,7 +58,8 @@ export default function SessionScreen({navigation}:any){
       <Pressable onPress={()=>navigation.navigate('Logbook')} style={btnGhost}><Text style={{color:colors.text}}>Logbook</Text></Pressable>
       <Pressable onPress={sync} style={btnGhost}><Text style={{color:colors.text}}>Sync</Text></Pressable>
       </View>
-    </ScrollView>
+      </ScrollView>
+    </Screen>
   );
 }
 const btn = { backgroundColor:'#0e2f36', borderWidth:1, borderColor:colors.neon, paddingVertical:10, paddingHorizontal:14, borderRadius:10 };

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -2,18 +2,21 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme/colors';
+import Screen from './_layout/Screen';
 
 export default function SettingsScreen({ navigation }: { navigation: any }) {
   // Log navigation prop
   console.log('[SettingsScreen] navigation prop:', navigation);
 
   return (
-    <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
-      <View style={styles.container}>
-        <Text style={styles.h1}>Settings</Text>
-        <Text style={styles.p}>(Add prefs like voice, theme, logging here)</Text>
-      </View>
-    </LinearGradient>
+    <Screen>
+      <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
+        <View style={styles.container}>
+          <Text style={styles.h1}>Settings</Text>
+          <Text style={styles.p}>(Add prefs like voice, theme, logging here)</Text>
+        </View>
+      </LinearGradient>
+    </Screen>
   );
 }
 const styles = StyleSheet.create({

--- a/src/screens/TransmissionScreen.tsx
+++ b/src/screens/TransmissionScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme/colors';
+import Screen from './_layout/Screen';
 
 // Added type annotation for navigation prop
 const TransmissionScreen = ({ navigation }: { navigation: any }) => {
@@ -9,12 +10,14 @@ const TransmissionScreen = ({ navigation }: { navigation: any }) => {
   console.log('[TransmissionScreen] navigation prop:', navigation);
 
   return (
-    <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
-      <View style={styles.container}>
-        <Text style={styles.h1}>Transmission</Text>
-        <Text style={styles.p}>Listening / responses will appear here.</Text>
-      </View>
-    </LinearGradient>
+    <Screen>
+      <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
+        <View style={styles.container}>
+          <Text style={styles.h1}>Transmission</Text>
+          <Text style={styles.p}>Listening / responses will appear here.</Text>
+        </View>
+      </LinearGradient>
+    </Screen>
   );
 };
 

--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -3,6 +3,7 @@ import { View, Text, Pressable, StyleSheet, Dimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../../theme';
 import { themeColors } from '../theme/theme';
+import Screen from './_layout/Screen';
 
 const { width, height } = Dimensions.get('window');
 
@@ -10,11 +11,12 @@ export default function WelcomeScreen({ navigation }: any) {
   console.log('WelcomeScreen navigation prop:', navigation);
   const { theme } = useTheme();
   return (
-    <LinearGradient
-      colors={[themeColors.card, themeColors.accent2, themeColors.neon]}
-      style={styles.gradient}
-    >
-      <View style={styles.container}>
+    <Screen>
+      <LinearGradient
+        colors={[themeColors.card, themeColors.accent2, themeColors.neon]}
+        style={styles.gradient}
+      >
+        <View style={styles.container}>
   <Text style={[styles.title, { color: themeColors.neon }]}>EchØVoid</Text>
   <Text style={[styles.subtitle, { color: themeColors.text }]}>Where echoes become answers.</Text>
         <Pressable
@@ -57,8 +59,9 @@ export default function WelcomeScreen({ navigation }: any) {
         >
           <Text style={[styles.buttonText, { color: themeColors.card }]}>AR Mode</Text>
         </Pressable>
-      </View>
-    </LinearGradient>
+        </View>
+      </LinearGradient>
+    </Screen>
   );
 }
 

--- a/src/screens/_layout/Screen.tsx
+++ b/src/screens/_layout/Screen.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { SafeAreaView, ViewStyle } from 'react-native';
+import NoiseOverlay from '../../../components/fx/NoiseOverlay';
+import ParticleField from '../../../components/fx/ParticleField';
+
+export default function Screen({ children, style }: { children: React.ReactNode; style?: ViewStyle }) {
+  return (
+    <SafeAreaView style={[{ flex: 1 }, style]}>
+      {children}
+      <NoiseOverlay />
+      <ParticleField />
+    </SafeAreaView>
+  );
+}
+


### PR DESCRIPTION
## Summary
- wrap all screens with a shared Screen component providing SafeAreaView and FX overlays
- remove per-screen overlay/SafeAreaView usage to avoid duplication
- add Screen layout for src screens and ensure navigation uses the wrapped components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef92cee90832eb41de3baf862e02c