### PR TITLE
refactor: use EVoidButton in EVP recorder

### DIFF
--- a/screens/EVPRecorder.tsx
+++ b/screens/EVPRecorder.tsx
@@ -1,11 +1,14 @@
 import React, { useState } from 'react';
-import { View, Text, Button, StyleSheet, Alert } from 'react-native';
+import { View, Text, StyleSheet, Alert } from 'react-native';
 import * as Recorder from '../services/audio/Recorder';
 import SessionStore from '../services/sessions/SessionStore';
 import SpectrogramPreview from '../components/evp/SpectrogramPreview';
 import { detectAnomalies } from '../src/core/anomaly/detector';
+import EVoidButton from '../components/ui/EVoidButton';
+import { useTheme } from '../theme';
 
 export default function EVPRecorder() {
+  const { theme } = useTheme();
   const [recording, setRecording] = useState(false);
   const [uri, setUri] = useState<string | null>(null);
   const [markers, setMarkers] = useState<number[]>([]);
@@ -55,17 +58,19 @@ export default function EVPRecorder() {
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>EVP Recorder</Text>
+    <View style={[styles.container, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[styles.title, { color: theme.colors.text }]}>EVP Recorder</Text>
       <View style={styles.status}>
-        <Text>Status: {recording ? 'Recording...' : uri ? 'Stopped' : 'Idle'}</Text>
-        {uri && <Text>File: {uri}</Text>}
-        {markers.length > 0 && <Text>Markers: {markers.join(', ')}</Text>}
+        <Text style={{ color: theme.colors.text }}>Status: {recording ? 'Recording...' : uri ? 'Stopped' : 'Idle'}</Text>
+        {uri && <Text style={{ color: theme.colors.text }}>File: {uri}</Text>}
+        {markers.length > 0 && <Text style={{ color: theme.colors.text }}>Markers: {markers.join(', ')}</Text>}
         {anomalies.length > 0 && (
           <View style={{ marginTop: 8 }}>
-            <Text>Anomalies Detected:</Text>
+            <Text style={{ color: theme.colors.text }}>Anomalies Detected:</Text>
             {anomalies.map((a, i) => (
-              <Text key={i}>{`Time: ${a.time}, Freq: ${Math.round(a.freq)}Hz, Confidence: ${Math.round(a.confidence * 100)}%`}</Text>
+              <Text key={i} style={{ color: theme.colors.text }}>
+                {`Time: ${a.time}, Freq: ${Math.round(a.freq)}Hz, Confidence: ${Math.round(a.confidence * 100)}%`}
+              </Text>
             ))}
           </View>
         )}
@@ -73,13 +78,19 @@ export default function EVPRecorder() {
       <SpectrogramPreview />
       <View style={styles.buttons}>
         {!recording ? (
-          <Button title="Start Recording" onPress={start} />
+          <EVoidButton label="Start Recording" onPress={start} style={styles.btn} />
         ) : (
-          <Button title="Stop Recording" onPress={stop} />
+          <EVoidButton label="Stop Recording" onPress={stop} variant="outline" style={styles.btn} />
         )}
-        {recording && <Button title="Mark Anomaly" onPress={mark} />}
-        {uri && <Button title="Save Session" onPress={saveSession} />}
-        {uri && <Button title="Play Recording" onPress={handlePlay} />}
+        {recording && (
+          <EVoidButton label="Mark Anomaly" onPress={mark} variant="outline" style={styles.btn} />
+        )}
+        {uri && (
+          <EVoidButton label="Save Session" onPress={saveSession} style={styles.btn} />
+        )}
+        {uri && (
+          <EVoidButton label="Play Recording" onPress={handlePlay} variant="outline" style={styles.btn} />
+        )}
       </View>
     </View>
   );
@@ -90,4 +101,5 @@ const styles = StyleSheet.create({
   title: { fontSize: 28, fontWeight: 'bold', marginBottom: 16 },
   status: { marginBottom: 24 },
   buttons: { gap: 12 },
+  btn: { minWidth: 180 },
 });


### PR DESCRIPTION
## Summary
- replace React Native Button in EVPRecorder with theme-aware EVoidButton
- hook recorder screen into theme system

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef935cab8832e90282cd6d949f6de