### PR TITLE
feat: add theme-based backgrounds

### DIFF
--- a/screens/_layout/Screen.tsx
+++ b/screens/_layout/Screen.tsx
@@ -1,14 +1,36 @@
-import React from 'react';
-import { SafeAreaView, ViewStyle } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { SafeAreaView, ViewStyle, Animated, ImageBackground, StyleSheet } from 'react-native';
 import NoiseOverlay from '../../components/fx/NoiseOverlay';
 import ParticleField from '../../components/fx/ParticleField';
-// TODO: Add ParticleField and other global FX as needed
+import { useTheme, backgroundAssets } from '../../src/theme/theme';
+
+const AnimatedImageBackground = Animated.createAnimatedComponent(ImageBackground);
+
 export default function Screen({ children, style }: { children: React.ReactNode; style?: ViewStyle }) {
+  const { theme } = useTheme();
+  const fade = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    fade.setValue(0);
+    Animated.timing(fade, {
+      toValue: 1,
+      duration: 600,
+      useNativeDriver: true,
+    }).start();
+  }, [theme.name]);
+
+  const source = backgroundAssets[theme.name];
+
   return (
     <SafeAreaView style={[{ flex: 1 }, style]}>
-      {children}
+      <AnimatedImageBackground
+        source={source}
+        resizeMode="cover"
+        style={[StyleSheet.absoluteFill, { opacity: fade }]}
+      />
       <NoiseOverlay />
       <ParticleField />
+      {children}
     </SafeAreaView>
   );
 }

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -1,11 +1,17 @@
+import React, { PropsWithChildren } from 'react';
+import { DefaultTheme, Theme as NavTheme } from '@react-navigation/native';
+import { colors } from './colors';
+import { ThemeProvider as BaseThemeProvider, useTheme, ThemeName } from '../../theme';
+
+// Re-export useTheme for convenience
+export { useTheme };
+
 // Custom theme colors for app screens (includes all keys)
 export const themeColors = {
   ...colors,
 };
-import React, { PropsWithChildren } from 'react';
-import { DefaultTheme, Theme as NavTheme } from '@react-navigation/native';
-import { colors } from './colors';
 
+// Navigation theme
 export const navTheme: NavTheme = {
   ...DefaultTheme,
   colors: {
@@ -19,30 +25,14 @@ export const navTheme: NavTheme = {
   },
 };
 
-import { ImageBackground, StyleSheet, View, Animated, Easing } from 'react-native';
+// Map theme name to background images
+export const backgroundAssets: Record<ThemeName, number> = {
+  Void: require('../../assets/bg-void.png'),
+  NeonFlux: require('../../assets/bg-neon.png'),
+  Astral: require('../../assets/bg-astral.png'),
+};
 
-export function ThemeProvider({ children }: PropsWithChildren) {
-
-  return (
-    <View style={{ flex: 1 }}>
-      {/* Gradient background for astral/spiritual effect */}
-      <View style={styles.gradientBg}>
-        {children}
-      </View>
-    </View>
-  );
+// Base theme provider wrapper
+export function ThemeProvider({ children }: PropsWithChildren<{}>) {
+  return <BaseThemeProvider>{children}</BaseThemeProvider>;
 }
-
-const styles = StyleSheet.create({
-  gradientBg: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    zIndex: -1,
-    backgroundColor: '#2C1B0F', // lighter brown for better contrast
-  },
-  bg: { flex: 1, width: '100%', height: '100%', justifyContent: 'center', backgroundColor: '#2C1B0F' },
-  overlay: { flex: 1, opacity: 0.08, justifyContent: 'center' }, // lower overlay opacity for brightness
-});


### PR DESCRIPTION
## Summary
- map themes to specific background images
- render screen background with fade-in based on current theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef93bb948832e8627c6054f56d7cb