### PR TITLE
feat(navigation): add custom transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-community/slider": "4.5.6",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.25",
+        "@react-navigation/stack": "^7.4.7",
         "expo": "~53.0.0",
         "expo-av": "~15.1.7",
         "expo-camera": "~16.1.11",
@@ -3632,6 +3633,24 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11"
+      }
+    },
+    "node_modules/@react-navigation/stack": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-7.4.7.tgz",
+      "integrity": "sha512-1VDxuou+iZXEK7o+ZtCIU3b+upAwLFolptEKX+GldUy78GR66hltPxmu8bJeb2ZcgUSowBTHw03kNY1gyOdW3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.6.3",
+        "color": "^4.2.3"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.17",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 2.0.0",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-native-community/slider": "4.5.6",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.25",
+    "@react-navigation/stack": "^7.4.7",
     "expo": "~53.0.0",
     "expo-av": "~15.1.7",
     "expo-camera": "~16.1.11",

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -5,13 +5,13 @@ import { useTheme } from '../theme';
 import ParticleField from '../components/fx/ParticleField';
 import EVoidButton from '../components/ui/EVoidButton';
 
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { StackNavigationProp } from '@react-navigation/stack';
 import type { RootStackParamList } from '../src/navigation/AppNavigator';
 import { useNavigation } from '@react-navigation/native';
 
 export default function Home() {
   const { theme } = useTheme();
-  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList, 'Home'>>();
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList, 'Home'>>();
   return (
     <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
       <ParticleField />

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { navTheme } from '../theme/theme';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createStackNavigator, TransitionPresets } from '@react-navigation/stack';
 
 import HomeScreen from '../screens/HomeScreen';
 import TransmissionScreen from '../screens/TransmissionScreen';
 import SettingsScreen from '../screens/SettingsScreen';
-import ARModeScreen from '../screens/ARModeScreen';
+import ARScreen from '../screens/ARScreen';
 
 import Logbook from '../../screens/Logbook';
 import SessionDetail from '../../components/logbook/SessionDetail';
@@ -25,7 +25,7 @@ export type RootStackParamList = {
   SessionDetail: { session: any };
 };
 
-const Stack = createNativeStackNavigator<RootStackParamList>();
+const Stack = createStackNavigator<RootStackParamList>();
 
 function AppNavigator() {
   // Log navigation container state
@@ -36,12 +36,25 @@ function AppNavigator() {
       theme={navTheme}
       onStateChange={(state) => console.log('[AppNavigator] Navigation state changed:', state)}
     >
-      <Stack.Navigator initialRouteName="Welcome" screenOptions={{ headerShown: false }}>
+      <Stack.Navigator
+        initialRouteName="Welcome"
+        screenOptions={{
+          headerShown: false,
+          ...TransitionPresets.SlideFromRightIOS,
+        }}
+      >
         <Stack.Screen name="Welcome" component={WelcomeScreen} />
         <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="Transmission" component={TransmissionScreen} />
         <Stack.Screen name="Settings" component={SettingsScreen} />
-        <Stack.Screen name="ARMode" component={ARModeScreen} />
+        <Stack.Screen
+          name="ARMode"
+          component={ARScreen}
+          options={{
+            presentation: 'modal',
+            ...TransitionPresets.ModalSlideFromBottomIOS,
+          }}
+        />
         <Stack.Screen name="Logbook" component={Logbook} />
         <Stack.Screen name="SessionDetail" component={SessionDetail} />
       </Stack.Navigator>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { View, Text, StyleSheet, StatusBar, Alert } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { StackScreenProps } from '@react-navigation/stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
 import UIButton from '../components/UIButton';
 import { colors } from '../theme/colors';
 import { hasNativeVoice, startListening } from '../voice/adapter';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
+type Props = StackScreenProps<RootStackParamList, 'Home'>;
 
 export default function HomeScreen({ navigation }: Props) {
   const onBegin = async () => {


### PR DESCRIPTION
## Summary
- use React Navigation stack with slide-from-right transitions for primary flow
- present AR mode screen as a modal with slide-from-bottom behavior
- update Home screens to use stack navigation prop types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef940b0e0832eae35ad5390514350