### PR TITLE
feat: centralize typography styles

### DIFF
--- a/components/controls/Chip.tsx
+++ b/components/controls/Chip.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import { useTheme } from '../../theme';
+import { useTheme, Theme } from '../../theme';
 export default function Chip({ options, value, onChange }: {
   options: string[];
   value: string;
   onChange: (v: string) => void;
 }) {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <View style={styles.row}>
       {options.map(opt => (
@@ -21,8 +22,11 @@ export default function Chip({ options, value, onChange }: {
     </View>
   );
 }
-const styles = StyleSheet.create({
-  row: { flexDirection: 'row', gap: 8, marginVertical: 8 },
-  chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 2 },
-  text: { fontWeight: '600', fontSize: 14 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    row: { flexDirection: 'row', gap: 8, marginVertical: 8 },
+    chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 2 },
+    text: { ...theme.typography.caption, fontWeight: '600', fontSize: 14 },
+  });
+}

--- a/components/controls/Knob.tsx
+++ b/components/controls/Knob.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import { View, Text, PanResponder, StyleSheet } from 'react-native';
 import Animated, { useSharedValue, useAnimatedProps, withSpring } from 'react-native-reanimated';
 import Svg, { Circle, G, Path as SvgPath } from 'react-native-svg';
-import { useTheme } from '../../theme';
+import { useTheme, Theme } from '../../theme';
 const TICK_COUNT = 18;
 
 function polarToCartesian(cx: number, cy: number, r: number, angle: number) {
@@ -31,6 +31,7 @@ export default function Knob({ value, onChange, min = 0, max = 1, step = 0.01, s
   format?: string;
 }) {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   const angleRange = 270;
   const startAngle = 135;
   const endAngle = 405;
@@ -93,7 +94,10 @@ export default function Knob({ value, onChange, min = 0, max = 1, step = 0.01, s
     </View>
   );
 }
-const styles = StyleSheet.create({
-  label: { fontWeight: '600', marginTop: 2 },
-  value: { fontWeight: '700', fontSize: 16 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    label: { ...theme.typography.label, marginTop: 2 },
+    value: { ...theme.typography.button },
+  });
+}

--- a/components/controls/Slider.tsx
+++ b/components/controls/Slider.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Slider from '@react-native-community/slider';
-import { useTheme } from '../../theme';
+import { useTheme, Theme } from '../../theme';
 export default function EVoidSlider({ value, onChange, min = 0, max = 1, step = 0.01, label, format }: {
   value: number;
   onChange: (v: number) => void;
@@ -12,6 +12,7 @@ export default function EVoidSlider({ value, onChange, min = 0, max = 1, step = 
   format?: string;
 }) {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <View style={styles.wrap}>
       {label && <Text style={[styles.label, { color: theme.colors.text }]}>{label}</Text>}
@@ -30,9 +31,12 @@ export default function EVoidSlider({ value, onChange, min = 0, max = 1, step = 
     </View>
   );
 }
-const styles = StyleSheet.create({
-  wrap: { width: '100%', marginVertical: 8 },
-  label: { marginBottom: 4, fontWeight: '600' },
-  slider: { width: '100%' },
-  value: { fontWeight: '700', fontSize: 15, marginTop: 2 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    wrap: { width: '100%', marginVertical: 8 },
+    label: { ...theme.typography.label, marginBottom: 4 },
+    slider: { width: '100%' },
+    value: { ...theme.typography.body, fontWeight: '700', fontSize: 15, marginTop: 2 },
+  });
+}

--- a/components/controls/Timer.tsx
+++ b/components/controls/Timer.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withRepeat, withTiming } from 'react-native-reanimated';
+import { useTheme, Theme } from '../../theme';
 
 export default function Timer({ ms }: { ms: number }) {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
   const mm = Math.floor(ms / 60000).toString().padStart(2, '0');
   const ss = Math.floor((ms % 60000) / 1000).toString().padStart(2, '0');
   const scale = useSharedValue(1);
@@ -14,6 +17,9 @@ export default function Timer({ ms }: { ms: number }) {
   }));
   return <Animated.Text style={[styles.timer, style]}>{mm}:{ss}</Animated.Text>;
 }
-const styles = StyleSheet.create({
-  timer: { fontSize: 22, fontWeight: '700', letterSpacing: 1, color: '#fff', textAlign: 'center' },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    timer: { ...theme.typography.heading3, letterSpacing: 1, color: theme.colors.text, textAlign: 'center' },
+  });
+}

--- a/components/logbook/SessionDetail.tsx
+++ b/components/logbook/SessionDetail.tsx
@@ -3,11 +3,14 @@ import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { Audio } from 'expo-av';
 import EVoidButton from '../ui/EVoidButton';
 import { shareSessionZip } from '../../services/export/zipSession';
+import { useTheme, Theme } from '../../theme';
 
 export default function SessionDetail({ route }: any) {
   const session = route?.params?.session;
   const [playing, setPlaying] = useState(false);
   const soundRef = useRef<Audio.Sound | null>(null);
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
 
   const handlePlay = async () => {
     if (!session?.uri) return;
@@ -56,13 +59,16 @@ export default function SessionDetail({ route }: any) {
       ) : (
         <Text style={styles.value}>None</Text>
       )}
-  <EVoidButton label="Export Session" onPress={() => shareSessionZip(session)} style={{ marginTop: 24 }} />
+      <EVoidButton label="Export Session" onPress={() => shareSessionZip(session)} style={{ marginTop: 24 }} />
     </ScrollView>
   );
 }
-const styles = StyleSheet.create({
-  detail: { flex: 1, padding: 20, backgroundColor: '#111' },
-  title: { fontSize: 24, fontWeight: '800', color: '#fff', marginBottom: 16 },
-  label: { color: '#aaa', fontWeight: '600', marginTop: 12 },
-  value: { color: '#fff', fontSize: 15, marginTop: 2 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    detail: { flex: 1, padding: 20, backgroundColor: '#111' },
+    title: { ...theme.typography.heading2, color: '#fff', marginBottom: 16 },
+    label: { ...theme.typography.label, color: '#aaa', marginTop: 12 },
+    value: { ...theme.typography.body, color: '#fff', marginTop: 2 },
+  });
+}

--- a/components/logbook/SessionItem.tsx
+++ b/components/logbook/SessionItem.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useTheme, Theme } from '../../theme';
+
 // TODO: Show session summary, type, date, and quick actions
 export default function SessionItem({ session, onDelete, onView }: { session: any; onDelete: () => void; onView: () => void }) {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <View style={styles.item}>
       <Text style={styles.type}>{session.type || 'Session'}</Text>
@@ -14,12 +18,15 @@ export default function SessionItem({ session, onDelete, onView }: { session: an
     </View>
   );
 }
-const styles = StyleSheet.create({
-  item: { padding: 16, borderRadius: 12, backgroundColor: '#222', marginVertical: 6 },
-  type: { color: '#fff', fontWeight: '700', fontSize: 16 },
-  date: { color: '#aaa', fontSize: 13, marginTop: 2 },
-  info: { color: '#8ff', fontSize: 13, marginTop: 4 },
-  actions: { flexDirection: 'row', marginTop: 8 },
-  actionButton: { marginRight: 12, padding: 8, backgroundColor: '#444', borderRadius: 8 },
-  actionText: { color: '#fff', fontSize: 13 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    item: { padding: 16, borderRadius: 12, backgroundColor: '#222', marginVertical: 6 },
+    type: { ...theme.typography.body, fontWeight: '700', color: '#fff' },
+    date: { ...theme.typography.caption, color: '#aaa', marginTop: 2 },
+    info: { ...theme.typography.caption, color: '#8ff', marginTop: 4 },
+    actions: { flexDirection: 'row', marginTop: 8 },
+    actionButton: { marginRight: 12, padding: 8, backgroundColor: '#444', borderRadius: 8 },
+    actionText: { ...theme.typography.caption, color: '#fff' },
+  });
+}

--- a/components/ui/EVoidButton.tsx
+++ b/components/ui/EVoidButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
-import { useTheme } from '../../theme';
+import { useTheme, Theme } from '../../theme';
 
 type Props = {
   label: string;
@@ -13,6 +13,7 @@ type Props = {
 
 export default function EVoidButton({ label, onPress, variant = 'solid', style, testID, disabled = false }: Props) {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <Pressable
       testID={testID}
@@ -35,7 +36,10 @@ export default function EVoidButton({ label, onPress, variant = 'solid', style, 
     </Pressable>
   );
 }
-const styles = StyleSheet.create({
-  btn: { paddingVertical: 14, paddingHorizontal: 20, borderRadius: 14, alignItems: 'center', marginVertical: 4 },
-  text: { fontSize: 16, fontWeight: '700', letterSpacing: 0.4 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    btn: { paddingVertical: 14, paddingHorizontal: 20, borderRadius: 14, alignItems: 'center', marginVertical: 4 },
+    text: { ...theme.typography.button },
+  });
+}

--- a/components/ui/EVoidChip.tsx
+++ b/components/ui/EVoidChip.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
-import { useTheme } from '../../theme';
+import { useTheme, Theme } from '../../theme';
 
 type Props = { label: string; selected?: boolean; style?: ViewStyle | ViewStyle[] };
 export default function EVoidChip({ label, selected, style }: Props) {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <View style={[styles.chip, { backgroundColor: selected ? theme.colors.accent : theme.colors.surface }, style]}>
       <Text style={[styles.text, { color: selected ? theme.colors.bg : theme.colors.text }]}>{label}</Text>
     </View>
   );
 }
-const styles = StyleSheet.create({
-  chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 4 },
-  text: { fontWeight: '600', fontSize: 14 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 4 },
+    text: { ...theme.typography.caption, fontWeight: '600', fontSize: 14 },
+  });
+}

--- a/components/ui/EVoidDialog.tsx
+++ b/components/ui/EVoidDialog.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { Modal, View, Text, StyleSheet } from 'react-native';
-import { useTheme } from '../../theme';
+import { useTheme, Theme } from '../../theme';
 
 type Props = { visible: boolean; title: string; children: React.ReactNode; onClose: () => void };
 export default function EVoidDialog({ visible, title, children, onClose }: Props) {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <View style={styles.overlay}>
-        <View style={[styles.dialog, { backgroundColor: theme.colors.surface }]}> 
+        <View style={[styles.dialog, { backgroundColor: theme.colors.surface }]}>
           <Text style={[styles.title, { color: theme.colors.text }]}>{title}</Text>
           {children}
         </View>
@@ -16,8 +17,11 @@ export default function EVoidDialog({ visible, title, children, onClose }: Props
     </Modal>
   );
 }
-const styles = StyleSheet.create({
-  overlay: { flex: 1, backgroundColor: '#0009', justifyContent: 'center', alignItems: 'center' },
-  dialog: { borderRadius: 18, padding: 24, minWidth: 260 },
-  title: { fontWeight: '700', fontSize: 18, marginBottom: 12 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    overlay: { flex: 1, backgroundColor: '#0009', justifyContent: 'center', alignItems: 'center' },
+    dialog: { borderRadius: 18, padding: 24, minWidth: 260 },
+    title: { ...theme.typography.heading3, marginBottom: 12 },
+  });
+}

--- a/components/ui/EVoidListItem.tsx
+++ b/components/ui/EVoidListItem.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
-import { useTheme } from '../../theme';
+import { useTheme, Theme } from '../../theme';
 
 type Props = { title: string; subtitle?: string; right?: React.ReactNode; style?: ViewStyle | ViewStyle[] };
 export default function EVoidListItem({ title, subtitle, right, style }: Props) {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <View style={[styles.item, { backgroundColor: theme.colors.surface }, style]}>
       <View style={{ flex: 1 }}>
@@ -15,8 +16,11 @@ export default function EVoidListItem({ title, subtitle, right, style }: Props) 
     </View>
   );
 }
-const styles = StyleSheet.create({
-  item: { flexDirection: 'row', alignItems: 'center', padding: 16, borderRadius: 12, marginVertical: 4 },
-  title: { fontWeight: '700', fontSize: 16 },
-  subtitle: { fontSize: 13, marginTop: 2 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    item: { flexDirection: 'row', alignItems: 'center', padding: 16, borderRadius: 12, marginVertical: 4 },
+    title: { ...theme.typography.body, fontWeight: '700' },
+    subtitle: { ...theme.typography.caption, marginTop: 2 },
+  });
+}

--- a/components/ui/EVoidToast.tsx
+++ b/components/ui/EVoidToast.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useTheme } from '../../theme';
+import { useTheme, Theme } from '../../theme';
 
 type Props = { message: string; type?: 'info' | 'danger' | 'success' };
 export default function EVoidToast({ message, type = 'info' }: Props) {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   const color = type === 'danger' ? theme.colors.danger : type === 'success' ? theme.colors.accent : theme.colors.primary;
   return (
-    <View style={[styles.toast, { borderColor: color }]}> 
+    <View style={[styles.toast, { borderColor: color }]}>
       <Text style={[styles.text, { color }]}>{message}</Text>
     </View>
   );
 }
-const styles = StyleSheet.create({
-  toast: { position: 'absolute', bottom: 32, left: 24, right: 24, backgroundColor: '#222E', borderRadius: 12, borderWidth: 2, padding: 16, alignItems: 'center' },
-  text: { fontWeight: '700', fontSize: 15 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    toast: { position: 'absolute', bottom: 32, left: 24, right: 24, backgroundColor: '#222E', borderRadius: 12, borderWidth: 2, padding: 16, alignItems: 'center' },
+    text: { ...theme.typography.body, fontWeight: '700' },
+  });
+}

--- a/screens/EVPRecorder.tsx
+++ b/screens/EVPRecorder.tsx
@@ -4,12 +4,15 @@ import * as Recorder from '../services/audio/Recorder';
 import SessionStore from '../services/sessions/SessionStore';
 import SpectrogramPreview from '../components/evp/SpectrogramPreview';
 import { detectAnomalies } from '../src/core/anomaly/detector';
+import { useTheme, Theme } from '../theme';
 
 export default function EVPRecorder() {
   const [recording, setRecording] = useState(false);
   const [uri, setUri] = useState<string | null>(null);
   const [markers, setMarkers] = useState<number[]>([]);
   const [anomalies, setAnomalies] = useState<any[]>([]);
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
 
   const start = async () => {
     await Recorder.startRecording();
@@ -85,9 +88,11 @@ export default function EVPRecorder() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  title: { fontSize: 28, fontWeight: 'bold', marginBottom: 16 },
-  status: { marginBottom: 24 },
-  buttons: { gap: 12 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+    title: { ...theme.typography.heading1, marginBottom: 16 },
+    status: { marginBottom: 24 },
+    buttons: { gap: 12 },
+  });
+}

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -1,7 +1,7 @@
 
 
 import { View, Text, StyleSheet, Image } from 'react-native';
-import { useTheme } from '../theme';
+import { useTheme, Theme } from '../theme';
 import ParticleField from '../components/fx/ParticleField';
 import EVoidButton from '../components/ui/EVoidButton';
 
@@ -11,9 +11,10 @@ import { useNavigation } from '@react-navigation/native';
 
 export default function Home() {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList, 'Home'>>();
   return (
-    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
       <ParticleField />
       <View style={styles.center}>
         <Image source={require('../assets/logo.svg')} style={{ width: 96, height: 96, marginBottom: 16 }} />
@@ -27,10 +28,12 @@ export default function Home() {
   );
 }
 
-const styles = StyleSheet.create({
-  flex: { flex: 1 },
-  center: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 },
-  title: { fontSize: 40, fontWeight: '900', letterSpacing: 1, textTransform: 'uppercase' },
-  subtitle: { fontSize: 16, marginBottom: 24, fontWeight: '600' },
-  btn: { width: 220, marginVertical: 6 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    flex: { flex: 1 },
+    center: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 },
+    title: { ...theme.typography.display, textTransform: 'uppercase' },
+    subtitle: { ...theme.typography.label, marginBottom: 24 },
+    btn: { width: 220, marginVertical: 6 },
+  });
+}

--- a/screens/LiveITC.tsx
+++ b/screens/LiveITC.tsx
@@ -4,7 +4,7 @@ import { createEngine, PRESETS } from '../src/core/audio/evpEngine';
 import { WORD_BANK } from '../src/core/audio/wordBank';
 import LiveChain from '../services/audio/LiveChain';
 import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
-import { useTheme } from '../theme';
+import { useTheme, Theme } from '../theme';
 import VU from '../components/controls/VU';
 import Knob from '../components/controls/Knob';
 import EVoidSlider from '../components/controls/Slider';
@@ -19,6 +19,7 @@ import EVoidButton from '../components/ui/EVoidButton';
 
 function LiveITC() {
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   const engineRef = useRef(null);
   const liveChainActive = useRef(false);
   const [gain, setGain] = useState(0.7);
@@ -105,7 +106,7 @@ function LiveITC() {
   };
 
   return (
-    <SafeAreaView style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
+    <SafeAreaView style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
       <NoiseOverlay />
       <View style={styles.header}>
         <Text style={[styles.title, { color: theme.colors.text }]}>Live ITC</Text>
@@ -116,14 +117,12 @@ function LiveITC() {
           <EVoidButton label={playing ? "Stop" : "Play"} onPress={playing ? () => setPlaying(false) : handlePlay} />
         </View>
         {recordingUri && (
-          <Text style={{ color: theme.colors.accent, fontSize: 14, marginTop: 8 }}>
-            Recording saved: {recordingUri}
-          </Text>
+          <Text style={[theme.typography.caption, { color: theme.colors.accent, marginTop: 8 }]}>Recording saved: {recordingUri}</Text>
         )}
         <View style={{ marginTop: 12 }}>
-          <Text style={{ color: theme.colors.text, fontSize: 12 }}>Magnetometer: {mag.map(v => v.toFixed(2)).join(', ')}</Text>
-          <Text style={{ color: theme.colors.text, fontSize: 12 }}>Accelerometer: {acc.map(v => v.toFixed(2)).join(', ')}</Text>
-          {word && <Text style={{ color: theme.colors.accent, fontSize: 18, marginTop: 8 }}>ITC Word: {word}</Text>}
+          <Text style={[theme.typography.small, { color: theme.colors.text }]}>Magnetometer: {mag.map(v => v.toFixed(2)).join(', ')}</Text>
+          <Text style={[theme.typography.small, { color: theme.colors.text }]}>Accelerometer: {acc.map(v => v.toFixed(2)).join(', ')}</Text>
+          {word && <Text style={[theme.typography.heading3, { color: theme.colors.accent, marginTop: 8 }]}>ITC Word: {word}</Text>}
         </View>
       </View>
       <AudioReactiveBars />
@@ -141,10 +140,12 @@ function LiveITC() {
   );
 }
 
-const styles = StyleSheet.create({
-  flex: { flex: 1 },
-  header: { alignItems: 'center', marginTop: 16, marginBottom: 8 },
-  title: { fontSize: 28, fontWeight: '800', letterSpacing: 1 },
-  row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 16, marginVertical: 12 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    flex: { flex: 1 },
+    header: { alignItems: 'center', marginTop: 16, marginBottom: 8 },
+    title: { ...theme.typography.heading1, letterSpacing: 1 },
+    row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 16, marginVertical: 12 },
+  });
+}
 

--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -2,9 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
 import SessionStore from '../services/sessions/SessionStore';
 import SessionItem from '../components/logbook/SessionItem';
+import { useTheme, Theme } from '../theme';
 
 export default function Logbook({ navigation }: any) {
   const [sessions, setSessions] = useState<any[]>([]);
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
   useEffect(() => {
     (async () => {
       const list = await SessionStore.list();
@@ -30,8 +33,10 @@ export default function Logbook({ navigation }: any) {
   );
 }
 
-const styles = StyleSheet.create({
-  flex: { flex: 1, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', margin: 16 },
-  empty: { color: '#888', textAlign: 'center', marginTop: 40 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    flex: { flex: 1, backgroundColor: '#111' },
+    title: { ...theme.typography.heading1, color: '#fff', margin: 16 },
+    empty: { ...theme.typography.body, color: '#888', textAlign: 'center', marginTop: 40 },
+  });
+}

--- a/screens/Onboarding/HowTo.tsx
+++ b/screens/Onboarding/HowTo.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { useTheme, Theme } from '../../theme';
 
 export default function OnboardingHowTo({ navigation }: any) {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>How to Use Ech0Void</Text>
@@ -17,9 +20,11 @@ export default function OnboardingHowTo({ navigation }: any) {
   );
 }
 
-const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
-  btn: { minWidth: 160 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
+    title: { ...theme.typography.heading1, color: '#fff', marginBottom: 24 },
+    body: { ...theme.typography.body, color: '#ccc', textAlign: 'center', marginBottom: 32 },
+    btn: { minWidth: 160 },
+  });
+}

--- a/screens/Onboarding/Intro.tsx
+++ b/screens/Onboarding/Intro.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { useTheme, Theme } from '../../theme';
 
 export default function OnboardingIntro({ navigation }: any) {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>Welcome to Ech0Void</Text>
       <Text style={styles.body}>
-        Ech0Void is a modern ITC toolkit for exploring anomalous audio, spirit communication, and creative consciousness. 
+        Ech0Void is a modern ITC toolkit for exploring anomalous audio, spirit communication, and creative consciousness.
         Record, analyze, and share your sessions with a beautiful, intuitive interface.
       </Text>
       <EVoidButton label="How to Use" onPress={() => navigation?.navigate?.('OnboardingHowTo')} style={styles.btn} />
@@ -15,9 +18,11 @@ export default function OnboardingIntro({ navigation }: any) {
   );
 }
 
-const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
-  btn: { minWidth: 160 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
+    title: { ...theme.typography.heading1, color: '#fff', marginBottom: 24 },
+    body: { ...theme.typography.body, color: '#ccc', textAlign: 'center', marginBottom: 32 },
+    btn: { minWidth: 160 },
+  });
+}

--- a/screens/Onboarding/Privacy.tsx
+++ b/screens/Onboarding/Privacy.tsx
@@ -2,14 +2,19 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useTheme, Theme } from '../../theme';
 
 export default function OnboardingPrivacy({ navigation }: any) {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>Privacy & Permissions</Text>
       <Text style={styles.body}>
-        Ech0Void only requests permissions needed for audio recording and file access.{"\n"}
-        Your data is stored locally and never shared without your consent.{"\n"}
+        Ech0Void only requests permissions needed for audio recording and file access{'
+'}
+        Your data is stored locally and never shared without your consent{'
+'}
         You can export or delete your sessions at any time from the Logbook.
       </Text>
       <EVoidButton label="Get Started" onPress={async () => {
@@ -24,9 +29,11 @@ export default function OnboardingPrivacy({ navigation }: any) {
   );
 }
 
-const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
-  btn: { minWidth: 160 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
+    title: { ...theme.typography.heading1, color: '#fff', marginBottom: 24 },
+    body: { ...theme.typography.body, color: '#ccc', textAlign: 'center', marginBottom: 32 },
+    btn: { minWidth: 160 },
+  });
+}

--- a/screens/Settings.tsx
+++ b/screens/Settings.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useTheme, themes, ThemeName } from '../theme';
+import { useTheme, themes, ThemeName, Theme } from '../theme';
 import Chip from '../components/controls/Chip';
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
+  const styles = createStyles(theme);
   return (
-    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
       <Text style={[styles.title, { color: theme.colors.text }]}>Settings</Text>
       <Text style={[styles.label, { color: theme.colors.text }]}>Theme</Text>
       <Chip
         options={Object.keys(themes) as ThemeName[]}
         value={theme.name}
-  onChange={v => setTheme(v as ThemeName)}
+        onChange={v => setTheme(v as ThemeName)}
       />
       <Text style={[styles.label, { color: theme.colors.text }]}>Audio FX (coming soon)</Text>
       <Text style={[styles.label, { color: theme.colors.text }]}>Performance (coming soon)</Text>
@@ -21,8 +22,10 @@ export default function Settings() {
   );
 }
 
-const styles = StyleSheet.create({
-  flex: { flex: 1, padding: 24 },
-  title: { fontSize: 28, fontWeight: '800', marginBottom: 24 },
-  label: { fontSize: 16, fontWeight: '600', marginTop: 18 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    flex: { flex: 1, padding: 24 },
+    title: { ...theme.typography.heading1, marginBottom: 24 },
+    label: { ...theme.typography.label, marginTop: 18 },
+  });
+}

--- a/screens/SigilMaker.tsx
+++ b/screens/SigilMaker.tsx
@@ -2,10 +2,13 @@ import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 import buildSigil from '../services/sigil/buildSigil';
+import { useTheme, Theme } from '../theme';
 
 export default function SigilMaker() {
   const [phrase, setPhrase] = useState('');
   const [sigilPath, setSigilPath] = useState('');
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
 
   const handleGenerate = () => {
     setSigilPath(buildSigil(phrase));
@@ -32,9 +35,11 @@ export default function SigilMaker() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
-  title: { fontSize: 24, marginBottom: 16 },
-  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, width: '100%', marginBottom: 16 },
-  button: { color: 'blue', marginBottom: 16 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
+    title: { ...theme.typography.heading2, marginBottom: 16 },
+    input: { borderWidth: 1, borderColor: '#ccc', padding: 8, width: '100%', marginBottom: 16 },
+    button: { ...theme.typography.button, color: 'blue', marginBottom: 16 },
+  });
+}

--- a/screens/SpiritBoard.tsx
+++ b/screens/SpiritBoard.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import getEntropy from '../services/rng/Entropy';
+import { useTheme, Theme } from '../theme';
 
 const LETTERS = [
   ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
@@ -12,6 +13,8 @@ const LETTERS = [
 
 export default function SpiritBoard() {
   const [pointer, setPointer] = useState({ row: 1, col: 3 });
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
 
   // Use entropy from sensors for pointer movement
   useEffect(() => {
@@ -51,13 +54,15 @@ export default function SpiritBoard() {
   );
 }
 
-const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  grid: { marginBottom: 32 },
-  row: { flexDirection: 'row' },
-  cell: { width: 44, height: 44, borderRadius: 22, backgroundColor: '#222', margin: 6, alignItems: 'center', justifyContent: 'center' },
-  pointer: { backgroundColor: '#00E0FF', borderWidth: 2, borderColor: '#fff' },
-  letter: { color: '#fff', fontSize: 22, fontWeight: '700' },
-  tip: { color: '#aaa', fontSize: 13, marginTop: 12 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    flex: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#111' },
+    title: { ...theme.typography.heading1, color: '#fff', marginBottom: 24 },
+    grid: { marginBottom: 32 },
+    row: { flexDirection: 'row' },
+    cell: { width: 44, height: 44, borderRadius: 22, backgroundColor: '#222', margin: 6, alignItems: 'center', justifyContent: 'center' },
+    pointer: { backgroundColor: '#00E0FF', borderWidth: 2, borderColor: '#fff' },
+    letter: { ...theme.typography.heading3, fontSize: 22, color: '#fff' },
+    tip: { ...theme.typography.caption, color: '#aaa', marginTop: 12 },
+  });
+}

--- a/src/components/UIButton.tsx
+++ b/src/components/UIButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
+import { useTheme, Theme } from '../../theme';
 
 type Props = {
   label: string;
@@ -9,6 +10,8 @@ type Props = {
 };
 
 export default function UIButton({ label, onPress, style, testID }: Props) {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <Pressable
       testID={testID}
@@ -30,19 +33,16 @@ export default function UIButton({ label, onPress, style, testID }: Props) {
   );
 }
 
-const styles = StyleSheet.create({
-  btn: {
-    paddingVertical: 14,
-    paddingHorizontal: 20,
-    borderRadius: 14,
-    backgroundColor: '#111827',
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.10)',
-  },
-  text: {
-    color: 'white',
-    fontSize: 16,
-    fontWeight: '700',
-    letterSpacing: 0.4,
-  },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    btn: {
+      paddingVertical: 14,
+      paddingHorizontal: 20,
+      borderRadius: 14,
+      backgroundColor: '#111827',
+      borderWidth: 1,
+      borderColor: 'rgba(255,255,255,0.10)',
+    },
+    text: { ...theme.typography.button, color: theme.colors.text },
+  });
+}

--- a/src/screens/ARModeScreen.tsx
+++ b/src/screens/ARModeScreen.tsx
@@ -6,6 +6,7 @@ import { GLView } from 'expo-gl';
 import { Renderer } from 'expo-three';
 import * as THREE from 'three';
 import { colors } from '../theme/colors';
+import { useTheme, Theme } from '../../theme';
 
 const { width, height } = Dimensions.get('window');
 
@@ -17,6 +18,8 @@ export default function ARModeScreen({ navigation }: any) {
   const hasPermission = permission?.granted ?? false;
   const cameraRef = useRef(null);
   const [type] = useState(CameraType.Back);
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
 
   useEffect(() => {
     if (!hasPermission) requestPermission();
@@ -82,8 +85,10 @@ export default function ARModeScreen({ navigation }: any) {
   );
 }
 
-const styles = StyleSheet.create({
-  overlay: { position: 'absolute', top: 0, left: 0, right: 0, padding: 24, alignItems: 'center' },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700', marginTop: 32 },
-  p: { color: colors.subtext, marginTop: 8 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    overlay: { position: 'absolute', top: 0, left: 0, right: 0, padding: 24, alignItems: 'center' },
+    h1: { ...theme.typography.heading1, color: colors.text, marginTop: 32 },
+    p: { ...theme.typography.body, color: colors.subtext, marginTop: 8 },
+  });
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -6,10 +6,13 @@ import type { RootStackParamList } from '../navigation/AppNavigator';
 import UIButton from '../components/UIButton';
 import { colors } from '../theme/colors';
 import { hasNativeVoice, startListening } from '../voice/adapter';
+import { useTheme, Theme } from '../../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 export default function HomeScreen({ navigation }: Props) {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
   const onBegin = async () => {
     console.log('[Home] Begin pressed');
     console.log('[HomeScreen] Navigating to Transmission');
@@ -49,37 +52,35 @@ export default function HomeScreen({ navigation }: Props) {
   );
 }
 
-const styles = StyleSheet.create({
-  flex: { flex: 1 },
-  container: {
-    flex: 1,
-    padding: 24,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 12,
-  },
-  title: {
-    color: colors.text, fontSize: 44, fontWeight: '900', letterSpacing: 1, textTransform: 'uppercase',
-  },
-  subtitle: {
-    color: colors.subtext, marginTop: 6, marginBottom: 18,
-  },
-  btn: {
-    width: '90%',
-    backgroundColor: '#12122B',
-    borderColor: colors.neon,
-  },
-  ring: {
-    position: 'absolute',
-    bottom: -40,
-    alignSelf: 'center',
-    width: 280,
-    height: 280,
-    borderRadius: 140,
-    borderWidth: 6,
-    borderColor: 'rgba(0,243,255,0.25)',
-    shadowColor: colors.neon,
-    shadowOpacity: 0.4,
-    shadowRadius: 24,
-  },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    flex: { flex: 1 },
+    container: {
+      flex: 1,
+      padding: 24,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 12,
+    },
+    title: { ...theme.typography.display, color: colors.text, fontSize: 44, textTransform: 'uppercase' },
+    subtitle: { ...theme.typography.body, color: colors.subtext, marginTop: 6, marginBottom: 18 },
+    btn: {
+      width: '90%',
+      backgroundColor: '#12122B',
+      borderColor: colors.neon,
+    },
+    ring: {
+      position: 'absolute',
+      bottom: -40,
+      alignSelf: 'center',
+      width: 280,
+      height: 280,
+      borderRadius: 140,
+      borderWidth: 6,
+      borderColor: 'rgba(0,243,255,0.25)',
+      shadowColor: colors.neon,
+      shadowOpacity: 0.4,
+      shadowRadius: 24,
+    },
+  });
+}

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -8,6 +8,7 @@ import Toggle from '../components/Toggle';
 import { speakEsmera } from '../core/audio/tts';
 import { useTranscription } from '../core/audio/transcription';
 import { detectAnomalies, setSensitivity } from '../core/anomaly/detector';
+import { useTheme } from '../../theme';
 
 export default function SessionScreen({navigation}:any){
   const { engine, session, start, stop, sync } = useSession();
@@ -15,6 +16,7 @@ export default function SessionScreen({navigation}:any){
   const [amp,setAmp] = useState(0);
   const [mode,setMode] = useState<'Standard'|'Mana'|'Reverse'|'DreamLink'|'Shadow'|'CallAndResponse'>('Standard');
   const [hits,setHits] = useState<any[]>([]);
+  const { theme } = useTheme();
 
   useEffect(()=> engine.level$(setAmp), [engine]);
   useEffect(()=>{ const det = setInterval(()=>{
@@ -26,35 +28,34 @@ export default function SessionScreen({navigation}:any){
 
   return (
   <ScrollView style={{flex:1, backgroundColor:colors.bg}} contentContainerStyle={{padding:16, gap:16}}>
-      <Text style={{color:colors.text, fontSize:18}}>Mode</Text>
+      <Text style={[theme.typography.heading3, {color:colors.text}]}>Mode</Text>
       <View style={{flexDirection:'row', flexWrap:'wrap'}}>
         {(['Standard','Mana','Reverse','DreamLink','Shadow','CallAndResponse'] as const).map(m =>
           <Toggle key={m} label={m} active={mode===m} onPress={()=>setMode(m)} />
         )}
       </View>
 
-  <Text style={{color:colors.text, fontSize:18}}>Sweep / Meter</Text>
+  <Text style={[theme.typography.heading3, {color:colors.text}]}>Sweep / Meter</Text>
       <Visualizer level={amp}/>
     <Meter level={amp} color={colors.neon}/>
+  <Text style={[theme.typography.heading3, {color:colors.text, marginTop:8}]}>Transcript</Text>
+  <Text style={[theme.typography.body, {color:colors.neon}]}>{text || '…listening…'}</Text>
+    <Text style={[theme.typography.caption, {color:colors.neon2, opacity:conf==null?0.5:1}]}>confidence: {conf==null?'—':Math.round(conf*100)+'%'}</Text>
 
-  <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Transcript</Text>
-  <Text style={{color:colors.neon}}>{text || '…listening…'}</Text>
-    <Text style={{color:colors.neon2, opacity:conf==null?0.5:1}}>confidence: {conf==null?'—':Math.round(conf*100)+'%'}</Text>
-
-  <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Anomalies</Text>
-  {hits.map((h,i)=>(<Text key={i} style={{color:colors.neon2}}>{`hit @${Math.round(h.freq)}Hz (${Math.round(h.confidence*100)}%)`}</Text>))}
+  <Text style={[theme.typography.heading3, {color:colors.text, marginTop:8}]}>Anomalies</Text>
+  {hits.map((h,i)=>(<Text key={i} style={[theme.typography.body, {color:colors.neon2}]}>{`hit @${Math.round(h.freq)}Hz (${Math.round(h.confidence*100)}%)`}</Text>))}
 
       <View style={{flexDirection:'row', gap:12, marginTop:8}}>
         {!session
-          ? <Pressable onPress={()=>start(mode)} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Start</Text></Pressable>
-          : <Pressable onPress={()=>stop()} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Stop</Text></Pressable>}
+          ? <Pressable onPress={()=>start(mode)} style={btn}><Text style={[theme.typography.button, { color: colors.neon }]}>Start</Text></Pressable>
+          : <Pressable onPress={()=>stop()} style={btn}><Text style={[theme.typography.button, { color: colors.neon }]}>Stop</Text></Pressable>}
         {supported
           ? !listening
-            ? <Pressable onPress={startASR} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Listen</Text></Pressable>
-            : <Pressable onPress={stopASR} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Stop ASR</Text></Pressable>
-          : <Pressable onPress={onSpeak} style={btn}><Text style={{ color: colors.neon, fontWeight: "bold" }}>Speak</Text></Pressable>}
-      <Pressable onPress={()=>navigation.navigate('Logbook')} style={btnGhost}><Text style={{color:colors.text}}>Logbook</Text></Pressable>
-      <Pressable onPress={sync} style={btnGhost}><Text style={{color:colors.text}}>Sync</Text></Pressable>
+            ? <Pressable onPress={startASR} style={btn}><Text style={[theme.typography.button, { color: colors.neon }]}>Listen</Text></Pressable>
+            : <Pressable onPress={stopASR} style={btn}><Text style={[theme.typography.button, { color: colors.neon }]}>Stop ASR</Text></Pressable>
+          : <Pressable onPress={onSpeak} style={btn}><Text style={[theme.typography.button, { color: colors.neon }]}>Speak</Text></Pressable>}
+      <Pressable onPress={()=>navigation.navigate('Logbook')} style={btnGhost}><Text style={[theme.typography.button, {color:colors.text}]}>Logbook</Text></Pressable>
+      <Pressable onPress={sync} style={btnGhost}><Text style={[theme.typography.button, {color:colors.text}]}>Sync</Text></Pressable>
       </View>
     </ScrollView>
   );

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme/colors';
+import { useTheme, Theme } from '../../theme';
 
 export default function SettingsScreen({ navigation }: { navigation: any }) {
   // Log navigation prop
   console.log('[SettingsScreen] navigation prop:', navigation);
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
 
   return (
     <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
@@ -16,8 +19,11 @@ export default function SettingsScreen({ navigation }: { navigation: any }) {
     </LinearGradient>
   );
 }
-const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
-  p: { color: colors.subtext, marginTop: 8 },
-});
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+    h1: { ...theme.typography.heading1, color: colors.text },
+    p: { ...theme.typography.body, color: colors.subtext, marginTop: 8 },
+  });
+}

--- a/src/screens/TransmissionScreen.tsx
+++ b/src/screens/TransmissionScreen.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme/colors';
+import { useTheme, Theme } from '../../theme';
 
 // Added type annotation for navigation prop
 const TransmissionScreen = ({ navigation }: { navigation: any }) => {
   // Log navigation prop
   console.log('[TransmissionScreen] navigation prop:', navigation);
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
 
   return (
     <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
@@ -18,10 +21,12 @@ const TransmissionScreen = ({ navigation }: { navigation: any }) => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
-  p: { color: colors.subtext, marginTop: 8 },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+    h1: { ...theme.typography.heading1, color: colors.text },
+    p: { ...theme.typography.body, color: colors.subtext, marginTop: 8 },
+  });
+}
 
 export default TransmissionScreen;

--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, Pressable, StyleSheet, Dimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useTheme } from '../../theme';
+import { useTheme, Theme } from '../../theme';
 import { themeColors } from '../theme/theme';
 
 const { width, height } = Dimensions.get('window');
@@ -9,14 +9,15 @@ const { width, height } = Dimensions.get('window');
 export default function WelcomeScreen({ navigation }: any) {
   console.log('WelcomeScreen navigation prop:', navigation);
   const { theme } = useTheme();
+  const styles = createStyles(theme);
   return (
     <LinearGradient
       colors={[themeColors.card, themeColors.accent2, themeColors.neon]}
       style={styles.gradient}
     >
       <View style={styles.container}>
-  <Text style={[styles.title, { color: themeColors.neon }]}>EchØVoid</Text>
-  <Text style={[styles.subtitle, { color: themeColors.text }]}>Where echoes become answers.</Text>
+        <Text style={[styles.title, { color: themeColors.neon }]}>EchØVoid</Text>
+        <Text style={[styles.subtitle, { color: themeColors.text }]}>Where echoes become answers.</Text>
         <Pressable
           onPress={() => {
             if (navigation && typeof navigation.navigate === 'function') {
@@ -62,46 +63,30 @@ export default function WelcomeScreen({ navigation }: any) {
   );
 }
 
-const styles = StyleSheet.create({
-  gradient: { flex: 1, width, height },
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 32,
-  },
-  title: {
-    fontSize: 38,
-    fontWeight: '900',
-    letterSpacing: 2,
-    textShadowColor: '#000a',
-    textShadowOffset: { width: 0, height: 2 },
-    textShadowRadius: 12,
-  },
-  subtitle: {
-    fontSize: 18,
-    fontWeight: '500',
-    marginTop: 10,
-    marginBottom: 32,
-    opacity: 0.85,
-    textAlign: 'center',
-  },
-  button: {
-    marginTop: 18,
-    paddingVertical: 14,
-    paddingHorizontal: 36,
-    borderRadius: 16,
-    borderWidth: 2,
-    minWidth: 180,
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.18,
-    shadowRadius: 8,
-  },
-  buttonText: {
-    fontSize: 18,
-    fontWeight: '700',
-    letterSpacing: 1,
-  },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    gradient: { flex: 1, width, height },
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 32,
+    },
+    title: { ...theme.typography.display, fontSize: 38, letterSpacing: 2, textShadowColor: '#000a', textShadowOffset: { width: 0, height: 2 }, textShadowRadius: 12 },
+    subtitle: { ...theme.typography.heading3, fontWeight: '500', fontSize: 18, marginTop: 10, marginBottom: 32, opacity: 0.85, textAlign: 'center' },
+    button: {
+      marginTop: 18,
+      paddingVertical: 14,
+      paddingHorizontal: 36,
+      borderRadius: 16,
+      borderWidth: 2,
+      minWidth: 180,
+      alignItems: 'center',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.18,
+      shadowRadius: 8,
+    },
+    buttonText: { ...theme.typography.button, fontSize: 18, letterSpacing: 1 },
+  });
+}

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,5 +1,25 @@
-export const TYPE = {
-  h1: { fontSize: 28, fontWeight: '800', letterSpacing: 0.5 },
-  h2: { fontSize: 20, fontWeight: '700' },
-  body: { fontSize: 16, fontWeight: '400' }
+import { TextStyle } from 'react-native';
+
+export interface Typography {
+  heading1: TextStyle;
+  heading2: TextStyle;
+  heading3: TextStyle;
+  body: TextStyle;
+  label: TextStyle;
+  caption: TextStyle;
+  small: TextStyle;
+  button: TextStyle;
+  display: TextStyle;
+}
+
+export const typography: Typography = {
+  display: { fontSize: 40, fontWeight: '900', letterSpacing: 1 },
+  heading1: { fontSize: 28, fontWeight: '800', letterSpacing: 0.5 },
+  heading2: { fontSize: 24, fontWeight: '700' },
+  heading3: { fontSize: 20, fontWeight: '700' },
+  body: { fontSize: 16, fontWeight: '400' },
+  label: { fontSize: 16, fontWeight: '600' },
+  caption: { fontSize: 13, fontWeight: '400' },
+  small: { fontSize: 12, fontWeight: '400' },
+  button: { fontSize: 16, fontWeight: '700', letterSpacing: 0.4 },
 };

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, PropsWithChildren } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { typography } from '../src/theme/typography';
 
 export type ThemeName = 'Void' | 'NeonFlux' | 'Astral';
 
@@ -17,6 +18,7 @@ export interface Theme {
   radii: number[];
   shadow: string;
   opacity: { [k: string]: number };
+  typography: typeof typography;
 }
 
 export const themes: Record<ThemeName, Theme> = {
@@ -29,6 +31,7 @@ export const themes: Record<ThemeName, Theme> = {
     radii: [0, 6, 12, 20],
     shadow: '0 2px 8px #0008',
     opacity: { disabled: 0.4, overlay: 0.12 },
+    typography,
   },
   NeonFlux: {
     name: 'NeonFlux',
@@ -39,6 +42,7 @@ export const themes: Record<ThemeName, Theme> = {
     radii: [0, 6, 12, 20],
     shadow: '0 2px 8px #0008',
     opacity: { disabled: 0.4, overlay: 0.12 },
+    typography,
   },
   Astral: {
     name: 'Astral',
@@ -49,6 +53,7 @@ export const themes: Record<ThemeName, Theme> = {
     radii: [0, 6, 12, 20],
     shadow: '0 2px 8px #0008',
     opacity: { disabled: 0.4, overlay: 0.12 },
+    typography,
   },
 };
 


### PR DESCRIPTION
## Summary
- add shared typography tokens and theme support
- refactor components and screens to use theme.typography

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef9442e80832e8127987022d73712