### PR TITLE
feat: add high contrast theme

### DIFF
--- a/components/controls/Chip.tsx
+++ b/components/controls/Chip.tsx
@@ -13,9 +13,17 @@ export default function Chip({ options, value, onChange }: {
         <Pressable
           key={opt}
           onPress={() => onChange(opt)}
-          style={[styles.chip, { backgroundColor: value === opt ? theme.colors.accent : theme.colors.surface }]}
+          style={({ focused }) => [
+            styles.chip,
+            {
+              backgroundColor: value === opt ? theme.colors.accent : theme.colors.surface,
+              borderColor: theme.name === 'HighContrast' ? theme.colors.text : 'transparent',
+              borderWidth: theme.name === 'HighContrast' ? 2 : 0,
+            },
+            focused && theme.name === 'HighContrast' && { borderColor: theme.colors.accent },
+          ]}
         >
-          <Text style={[styles.text, { color: value === opt ? theme.colors.bg : theme.colors.text }]}>{opt}</Text>
+          <Text style={[theme.typography.chip, { color: value === opt ? theme.colors.bg : theme.colors.text }]}>{opt}</Text>
         </Pressable>
       ))}
     </View>
@@ -24,5 +32,4 @@ export default function Chip({ options, value, onChange }: {
 const styles = StyleSheet.create({
   row: { flexDirection: 'row', gap: 8, marginVertical: 8 },
   chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 2 },
-  text: { fontWeight: '600', fontSize: 14 },
 });

--- a/components/ui/EVoidButton.tsx
+++ b/components/ui/EVoidButton.tsx
@@ -19,11 +19,16 @@ export default function EVoidButton({ label, onPress, variant = 'solid', style, 
       accessibilityRole="button"
       hitSlop={12}
       onPress={disabled ? undefined : onPress}
-      style={({ pressed }) => [
+      style={({ pressed, focused }) => [
         styles.btn,
-        variant === 'outline' && { backgroundColor: 'transparent', borderColor: theme.colors.accent, borderWidth: 2 },
+        variant === 'outline' && { backgroundColor: 'transparent', borderColor: theme.colors.accent },
         variant === 'ghost' && { backgroundColor: 'transparent', borderWidth: 0 },
-        { backgroundColor: variant === 'solid' ? theme.colors.primary : 'transparent' },
+        {
+          backgroundColor: variant === 'solid' ? theme.colors.primary : 'transparent',
+          borderColor: theme.name === 'HighContrast' ? theme.colors.text : theme.colors.accent,
+          borderWidth: theme.name === 'HighContrast' ? 3 : variant === 'outline' ? 2 : 0,
+        },
+        focused && theme.name === 'HighContrast' && { borderColor: theme.colors.accent },
         pressed && !disabled && { opacity: 0.8 },
         disabled && { opacity: 0.5 },
         style,
@@ -31,11 +36,11 @@ export default function EVoidButton({ label, onPress, variant = 'solid', style, 
       pointerEvents={disabled ? 'none' : 'auto'}
       accessibilityState={{ disabled }}
     >
-      <Text style={[styles.text, { color: theme.colors.text }]}>{label}</Text>
+      <Text style={[theme.typography.body, styles.text, { color: theme.colors.text }]}>{label}</Text>
     </Pressable>
   );
 }
 const styles = StyleSheet.create({
   btn: { paddingVertical: 14, paddingHorizontal: 20, borderRadius: 14, alignItems: 'center', marginVertical: 4 },
-  text: { fontSize: 16, fontWeight: '700', letterSpacing: 0.4 },
+  text: { letterSpacing: 0.4 },
 });

--- a/components/ui/EVoidChip.tsx
+++ b/components/ui/EVoidChip.tsx
@@ -6,12 +6,21 @@ type Props = { label: string; selected?: boolean; style?: ViewStyle | ViewStyle[
 export default function EVoidChip({ label, selected, style }: Props) {
   const { theme } = useTheme();
   return (
-    <View style={[styles.chip, { backgroundColor: selected ? theme.colors.accent : theme.colors.surface }, style]}>
-      <Text style={[styles.text, { color: selected ? theme.colors.bg : theme.colors.text }]}>{label}</Text>
+    <View
+      style={[
+        styles.chip,
+        {
+          backgroundColor: selected ? theme.colors.accent : theme.colors.surface,
+          borderColor: theme.name === 'HighContrast' ? theme.colors.text : 'transparent',
+          borderWidth: theme.name === 'HighContrast' ? 2 : 0,
+        },
+        style,
+      ]}
+    >
+      <Text style={[theme.typography.chip, { color: selected ? theme.colors.bg : theme.colors.text }]}>{label}</Text>
     </View>
   );
 }
 const styles = StyleSheet.create({
   chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 4 },
-  text: { fontWeight: '600', fontSize: 14 },
 });

--- a/screens/Settings.tsx
+++ b/screens/Settings.tsx
@@ -1,28 +1,29 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useTheme, themes, ThemeName } from '../theme';
+import { useTheme, ThemeName } from '../theme';
 import Chip from '../components/controls/Chip';
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
+  const themeOptions: ThemeName[] = ['Void', 'NeonFlux', 'Astral', 'HighContrast'];
   return (
-    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
-      <Text style={[styles.title, { color: theme.colors.text }]}>Settings</Text>
-      <Text style={[styles.label, { color: theme.colors.text }]}>Theme</Text>
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[theme.typography.title, styles.title, { color: theme.colors.text }]}>Settings</Text>
+      <Text style={[theme.typography.label, styles.label, { color: theme.colors.text }]}>Theme</Text>
       <Chip
-        options={Object.keys(themes) as ThemeName[]}
+        options={themeOptions}
         value={theme.name}
-  onChange={v => setTheme(v as ThemeName)}
+        onChange={v => setTheme(v as ThemeName)}
       />
-      <Text style={[styles.label, { color: theme.colors.text }]}>Audio FX (coming soon)</Text>
-      <Text style={[styles.label, { color: theme.colors.text }]}>Performance (coming soon)</Text>
-      <Text style={[styles.label, { color: theme.colors.text }]}>Privacy (coming soon)</Text>
+      <Text style={[theme.typography.label, styles.label, { color: theme.colors.text }]}>Audio FX (coming soon)</Text>
+      <Text style={[theme.typography.label, styles.label, { color: theme.colors.text }]}>Performance (coming soon)</Text>
+      <Text style={[theme.typography.label, styles.label, { color: theme.colors.text }]}>Privacy (coming soon)</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   flex: { flex: 1, padding: 24 },
-  title: { fontSize: 28, fontWeight: '800', marginBottom: 24 },
-  label: { fontSize: 16, fontWeight: '600', marginTop: 18 },
+  title: { marginBottom: 24 },
+  label: { marginTop: 18 },
 });

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,5 +1,15 @@
 export const TYPE = {
-  h1: { fontSize: 28, fontWeight: '800', letterSpacing: 0.5 },
-  h2: { fontSize: 20, fontWeight: '700' },
-  body: { fontSize: 16, fontWeight: '400' }
+  title: { fontSize: 28, fontWeight: '800', letterSpacing: 0.5 },
+  label: { fontSize: 16, fontWeight: '600' },
+  body: { fontSize: 16, fontWeight: '400' },
+  chip: { fontSize: 14, fontWeight: '600' },
 };
+
+export const HIGH_CONTRAST_TYPE = {
+  title: { fontSize: 30, fontWeight: '900', letterSpacing: 0.5 },
+  label: { fontSize: 18, fontWeight: '700' },
+  body: { fontSize: 18, fontWeight: '600' },
+  chip: { fontSize: 16, fontWeight: '700' },
+};
+
+export type Typography = typeof TYPE;

--- a/src/theme/variants/highContrast.ts
+++ b/src/theme/variants/highContrast.ts
@@ -1,7 +1,8 @@
-import { colors } from '../colors';
 export const HIGH_CONTRAST = {
-  background: colors.bg,
+  bg: '#000000',
+  surface: '#000000',
   text: '#FFFFFF',
   primary: '#00FFFF',
-  accent: '#FF00FF'
+  accent: '#FF00FF',
+  danger: '#FF0000',
 };

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -1,7 +1,9 @@
 import React, { createContext, useContext, useState, useEffect, PropsWithChildren } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { HIGH_CONTRAST } from '../src/theme/variants/highContrast';
+import { TYPE, HIGH_CONTRAST_TYPE, Typography } from '../src/theme/typography';
 
-export type ThemeName = 'Void' | 'NeonFlux' | 'Astral';
+export type ThemeName = 'Void' | 'NeonFlux' | 'Astral' | 'HighContrast';
 
 export interface Theme {
   name: ThemeName;
@@ -17,6 +19,7 @@ export interface Theme {
   radii: number[];
   shadow: string;
   opacity: { [k: string]: number };
+  typography: Typography;
 }
 
 export const themes: Record<ThemeName, Theme> = {
@@ -29,6 +32,7 @@ export const themes: Record<ThemeName, Theme> = {
     radii: [0, 6, 12, 20],
     shadow: '0 2px 8px #0008',
     opacity: { disabled: 0.4, overlay: 0.12 },
+    typography: TYPE,
   },
   NeonFlux: {
     name: 'NeonFlux',
@@ -39,6 +43,7 @@ export const themes: Record<ThemeName, Theme> = {
     radii: [0, 6, 12, 20],
     shadow: '0 2px 8px #0008',
     opacity: { disabled: 0.4, overlay: 0.12 },
+    typography: TYPE,
   },
   Astral: {
     name: 'Astral',
@@ -49,6 +54,16 @@ export const themes: Record<ThemeName, Theme> = {
     radii: [0, 6, 12, 20],
     shadow: '0 2px 8px #0008',
     opacity: { disabled: 0.4, overlay: 0.12 },
+    typography: TYPE,
+  },
+  HighContrast: {
+    name: 'HighContrast',
+    colors: HIGH_CONTRAST,
+    spacing: [0, 4, 8, 16, 24, 32],
+    radii: [0, 6, 12, 20],
+    shadow: '0 2px 8px #0008',
+    opacity: { disabled: 0.4, overlay: 0.12 },
+    typography: HIGH_CONTRAST_TYPE,
   },
 };
 


### PR DESCRIPTION
## Summary
- add selectable high contrast theme and expose typography per theme
- list high contrast theme in settings and apply theme typography
- adjust button and chip components for clearer outlines under high contrast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef952cac4832eb64de5ac6bc737a0