### PR TITLE
Add haptic feedback and animated UI interactions

### DIFF
--- a/components/ui/EVoidButton.tsx
+++ b/components/ui/EVoidButton.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
+import React, { useRef } from 'react';
+import { Pressable, Text, StyleSheet, ViewStyle, Animated } from 'react-native';
+import HapticFeedback from 'react-native-haptic-feedback';
+import { prefs } from '../../hooks/usePrefs';
 import { useTheme } from '../../theme';
 
 type Props = {
@@ -11,28 +13,56 @@ type Props = {
   disabled?: boolean;
 };
 
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
 export default function EVoidButton({ label, onPress, variant = 'solid', style, testID, disabled = false }: Props) {
   const { theme } = useTheme();
+  const scale = useRef(new Animated.Value(1)).current;
+  const opacity = useRef(new Animated.Value(1)).current;
+
+  const handlePressIn = () => {
+    Animated.parallel([
+      Animated.spring(scale, { toValue: 0.97, useNativeDriver: true }),
+      Animated.timing(opacity, { toValue: 0.8, duration: 100, useNativeDriver: true }),
+    ]).start();
+  };
+
+  const handlePressOut = () => {
+    Animated.parallel([
+      Animated.spring(scale, { toValue: 1, useNativeDriver: true }),
+      Animated.timing(opacity, { toValue: 1, duration: 100, useNativeDriver: true }),
+    ]).start();
+  };
+
+  const handlePress = () => {
+    if (prefs.get('haptics', true)) {
+      HapticFeedback.trigger('impactMedium');
+    }
+    onPress();
+  };
+
   return (
-    <Pressable
+    <AnimatedPressable
       testID={testID}
       accessibilityRole="button"
       hitSlop={12}
-      onPress={disabled ? undefined : onPress}
-      style={({ pressed }) => [
+      onPress={disabled ? undefined : handlePress}
+      onPressIn={disabled ? undefined : handlePressIn}
+      onPressOut={disabled ? undefined : handlePressOut}
+      style={[
         styles.btn,
         variant === 'outline' && { backgroundColor: 'transparent', borderColor: theme.colors.accent, borderWidth: 2 },
         variant === 'ghost' && { backgroundColor: 'transparent', borderWidth: 0 },
         { backgroundColor: variant === 'solid' ? theme.colors.primary : 'transparent' },
-        pressed && !disabled && { opacity: 0.8 },
-        disabled && { opacity: 0.5 },
+        { transform: [{ scale }], opacity },
         style,
+        disabled && { opacity: 0.5 },
       ]}
       pointerEvents={disabled ? 'none' : 'auto'}
       accessibilityState={{ disabled }}
     >
       <Text style={[styles.text, { color: theme.colors.text }]}>{label}</Text>
-    </Pressable>
+    </AnimatedPressable>
   );
 }
 const styles = StyleSheet.create({

--- a/components/ui/EVoidToggle.tsx
+++ b/components/ui/EVoidToggle.tsx
@@ -1,22 +1,51 @@
-import React from 'react';
-import { Switch, View, Text, StyleSheet } from 'react-native';
+import React, { useRef } from 'react';
+import { Switch, Text, StyleSheet, Animated, Pressable } from 'react-native';
 import { useTheme } from '../../theme';
 
 type Props = { value: boolean; onValueChange: (v: boolean) => void; label?: string };
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
 export default function EVoidToggle({ value, onValueChange, label }: Props) {
   const { theme } = useTheme();
+  const scale = useRef(new Animated.Value(1)).current;
+  const opacity = useRef(new Animated.Value(1)).current;
+
+  const handlePressIn = () => {
+    Animated.parallel([
+      Animated.spring(scale, { toValue: 0.97, useNativeDriver: true }),
+      Animated.timing(opacity, { toValue: 0.8, duration: 100, useNativeDriver: true }),
+    ]).start();
+  };
+
+  const handlePressOut = () => {
+    Animated.parallel([
+      Animated.spring(scale, { toValue: 1, useNativeDriver: true }),
+      Animated.timing(opacity, { toValue: 1, duration: 100, useNativeDriver: true }),
+    ]).start();
+  };
+
+  const toggle = () => onValueChange(!value);
+
   return (
-    <View style={styles.row}>
+    <AnimatedPressable
+      onPress={toggle}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      style={[styles.row, { transform: [{ scale }], opacity }]}
+      accessibilityRole="switch"
+      accessibilityState={{ checked: value }}
+    >
       {label && <Text style={[styles.label, { color: theme.colors.text }]}>{label}</Text>}
       <Switch
         value={value}
-        onValueChange={onValueChange}
         trackColor={{ true: theme.colors.accent, false: theme.colors.surface }}
         thumbColor={value ? theme.colors.primary : theme.colors.surface}
+        pointerEvents="none"
       />
-    </View>
+    </AnimatedPressable>
   );
 }
+
 const styles = StyleSheet.create({
   row: { flexDirection: 'row', alignItems: 'center', marginVertical: 8 },
   label: { marginRight: 12, fontWeight: '600' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react": "^19.0.0",
         "react-native": "^0.79.5",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-haptic-feedback": "^2.3.3",
         "react-native-mmkv": "^3.3.0",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
@@ -8693,6 +8694,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-haptic-feedback": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/react-native-haptic-feedback/-/react-native-haptic-feedback-2.3.3.tgz",
+      "integrity": "sha512-svS4D5PxfNv8o68m9ahWfwje5NqukM3qLS48+WTdhbDkNUkOhP9rDfDSRHzlhk4zq+ISjyw95EhLeh8NkKX5vQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "^19.0.0",
     "react-native": "^0.79.5",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-haptic-feedback": "^2.3.3",
     "react-native-mmkv": "^3.3.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",

--- a/screens/Settings.tsx
+++ b/screens/Settings.tsx
@@ -2,17 +2,25 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme, themes, ThemeName } from '../theme';
 import Chip from '../components/controls/Chip';
+import EVoidToggle from '../components/ui/EVoidToggle';
+import { usePrefs } from '../hooks/usePrefs';
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
+  const [haptics, setHaptics] = usePrefs('haptics', true);
   return (
-    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
       <Text style={[styles.title, { color: theme.colors.text }]}>Settings</Text>
       <Text style={[styles.label, { color: theme.colors.text }]}>Theme</Text>
       <Chip
         options={Object.keys(themes) as ThemeName[]}
         value={theme.name}
-  onChange={v => setTheme(v as ThemeName)}
+        onChange={v => setTheme(v as ThemeName)}
+      />
+      <EVoidToggle
+        label="Haptic Feedback"
+        value={haptics}
+        onValueChange={setHaptics}
       />
       <Text style={[styles.label, { color: theme.colors.text }]}>Audio FX (coming soon)</Text>
       <Text style={[styles.label, { color: theme.colors.text }]}>Performance (coming soon)</Text>


### PR DESCRIPTION
## Summary
- integrate react-native-haptic-feedback for button presses
- add scale and opacity animations to buttons and toggles
- expose a Settings option to enable or disable haptics globally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef95ece54832ea61cb94685564c40