### PR TITLE
feat: enhance onboarding visuals

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -85,7 +85,10 @@ export default function App() {
         <EsmeraProvider>
           <NavigationContainer>
             {showOnboarding ? (
-              <Stack.Navigator initialRouteName="OnboardingIntro" screenOptions={{ headerShown: false }}>
+              <Stack.Navigator
+                initialRouteName="OnboardingIntro"
+                screenOptions={{ headerShown: false, animation: 'fade' }}
+              >
                 <Stack.Screen name="OnboardingIntro" component={OnboardingIntro} />
                 <Stack.Screen name="OnboardingHowTo" component={OnboardingHowTo} />
                 <Stack.Screen name="OnboardingPrivacy" component={OnboardingPrivacy} />

--- a/screens/Onboarding/HowTo.tsx
+++ b/screens/Onboarding/HowTo.tsx
@@ -1,25 +1,47 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useRef, useEffect } from 'react';
+import { View, Text, StyleSheet, Animated } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { useTheme } from '../../theme';
+import { TYPE } from '../../src/theme/typography';
 
 export default function OnboardingHowTo({ navigation }: any) {
+  const { theme } = useTheme();
+  const fade = useRef(new Animated.Value(0)).current;
+  const slide = useRef(new Animated.Value(-20)).current;
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(fade, { toValue: 1, duration: 600, useNativeDriver: true }),
+      Animated.timing(slide, { toValue: 0, duration: 600, useNativeDriver: true }),
+    ]).start();
+  }, []);
+
   return (
-    <View style={styles.flex}>
-      <Text style={styles.title}>How to Use Ech0Void</Text>
-      <Text style={styles.body}>
-        1. Begin a Live ITC session to record and mark anomalies.\n
-        2. Review your sessions in the Logbook.\n
-        3. Export, share, or analyze your results.\n
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
+      <Animated.Image
+        source={require('../../assets/logo.svg')}
+        style={[styles.logo, { opacity: fade, transform: [{ translateY: slide }] }]}
+      />
+      <Text style={[styles.title, { color: theme.colors.text }]}>How to Use Ech0Void</Text>
+      <Text style={[styles.body, { color: theme.colors.text, opacity: 0.8 }]}>
+        1. Begin a Live ITC session to record and mark anomalies.{"\n"}
+        2. Review your sessions in the Logbook.{"\n"}
+        3. Export, share, or analyze your results.{"\n"}
         4. Explore advanced features in Settings.
       </Text>
-      <EVoidButton label="Privacy & Permissions" onPress={() => navigation?.navigate?.('OnboardingPrivacy')} style={styles.btn} />
+      <EVoidButton
+        label="Privacy & Permissions"
+        onPress={() => navigation?.navigate?.('OnboardingPrivacy')}
+        style={styles.btn}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+  logo: { width: 96, height: 96, marginBottom: 16 },
+  title: { ...TYPE.h1, marginBottom: 24 },
+  body: { ...TYPE.body, textAlign: 'center', marginBottom: 32 },
   btn: { minWidth: 160 },
 });

--- a/screens/Onboarding/Intro.tsx
+++ b/screens/Onboarding/Intro.tsx
@@ -1,23 +1,45 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useRef, useEffect } from 'react';
+import { View, Text, StyleSheet, Animated } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { useTheme } from '../../theme';
+import { TYPE } from '../../src/theme/typography';
 
 export default function OnboardingIntro({ navigation }: any) {
+  const { theme } = useTheme();
+  const fade = useRef(new Animated.Value(0)).current;
+  const slide = useRef(new Animated.Value(-20)).current;
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(fade, { toValue: 1, duration: 600, useNativeDriver: true }),
+      Animated.timing(slide, { toValue: 0, duration: 600, useNativeDriver: true }),
+    ]).start();
+  }, []);
+
   return (
-    <View style={styles.flex}>
-      <Text style={styles.title}>Welcome to Ech0Void</Text>
-      <Text style={styles.body}>
-        Ech0Void is a modern ITC toolkit for exploring anomalous audio, spirit communication, and creative consciousness. 
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
+      <Animated.Image
+        source={require('../../assets/logo.svg')}
+        style={[styles.logo, { opacity: fade, transform: [{ translateY: slide }] }]}
+      />
+      <Text style={[styles.title, { color: theme.colors.text }]}>Welcome to Ech0Void</Text>
+      <Text style={[styles.body, { color: theme.colors.text, opacity: 0.8 }]}>
+        Ech0Void is a modern ITC toolkit for exploring anomalous audio, spirit communication, and creative consciousness.
         Record, analyze, and share your sessions with a beautiful, intuitive interface.
       </Text>
-      <EVoidButton label="How to Use" onPress={() => navigation?.navigate?.('OnboardingHowTo')} style={styles.btn} />
+      <EVoidButton
+        label="How to Use"
+        onPress={() => navigation?.navigate?.('OnboardingHowTo')}
+        style={styles.btn}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+  logo: { width: 96, height: 96, marginBottom: 16 },
+  title: { ...TYPE.h1, marginBottom: 24 },
+  body: { ...TYPE.body, textAlign: 'center', marginBottom: 32 },
   btn: { minWidth: 160 },
 });

--- a/screens/Onboarding/Privacy.tsx
+++ b/screens/Onboarding/Privacy.tsx
@@ -1,32 +1,58 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useRef, useEffect } from 'react';
+import { View, Text, StyleSheet, Animated } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useTheme } from '../../theme';
+import { TYPE } from '../../src/theme/typography';
 
 export default function OnboardingPrivacy({ navigation }: any) {
+  const { theme } = useTheme();
+  const fade = useRef(new Animated.Value(0)).current;
+  const slide = useRef(new Animated.Value(-20)).current;
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(fade, { toValue: 1, duration: 600, useNativeDriver: true }),
+      Animated.timing(slide, { toValue: 0, duration: 600, useNativeDriver: true }),
+    ]).start();
+  }, []);
+
   return (
-    <View style={styles.flex}>
-      <Text style={styles.title}>Privacy & Permissions</Text>
-      <Text style={styles.body}>
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}>
+      <Animated.Image
+        source={require('../../assets/logo.svg')}
+        style={[styles.logo, { opacity: fade, transform: [{ translateY: slide }] }]}
+      />
+      <Text style={[styles.title, { color: theme.colors.text }]}>Privacy & Permissions</Text>
+      <Text style={[styles.body, { color: theme.colors.text, opacity: 0.8 }]}>
         Ech0Void only requests permissions needed for audio recording and file access.{"\n"}
         Your data is stored locally and never shared without your consent.{"\n"}
         You can export or delete your sessions at any time from the Logbook.
       </Text>
-      <EVoidButton label="Get Started" onPress={async () => {
-        await AsyncStorage.setItem('onboarded', '1');
-        navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
-      }} style={styles.btn} />
-      <EVoidButton label="Skip Onboarding" onPress={async () => {
-        await AsyncStorage.setItem('onboarded', '1');
-        navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
-      }} style={[styles.btn, { marginTop: 16, backgroundColor: '#333' }]} />
+      <EVoidButton
+        label="Get Started"
+        onPress={async () => {
+          await AsyncStorage.setItem('onboarded', '1');
+          navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
+        }}
+        style={styles.btn}
+      />
+      <EVoidButton
+        label="Skip Onboarding"
+        onPress={async () => {
+          await AsyncStorage.setItem('onboarded', '1');
+          navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
+        }}
+        style={[styles.btn, { marginTop: 16, backgroundColor: theme.colors.surface }]}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+  logo: { width: 96, height: 96, marginBottom: 16 },
+  title: { ...TYPE.h1, marginBottom: 24 },
+  body: { ...TYPE.body, textAlign: 'center', marginBottom: 32 },
   btn: { minWidth: 160 },
 });


### PR DESCRIPTION
## Summary
- animate brand logo on onboarding screens
- apply theme colors and fonts to onboarding
- fade transitions between onboarding steps

## Testing
- `npm test` (fails: test failed)
- `npx tsc --noEmit` (fails: Option 'bundler' can only be used when 'module' is set to 'preserve' or 'es2015' or later)


------
https://chatgpt.com/codex/tasks/task_e_68aef973d54c832e94019b52a50b36fb