### PR TITLE
Fix TypeScript errors and improve Android compatibility

### DIFF
--- a/components/logbook/SessionItem.tsx
+++ b/components/logbook/SessionItem.tsx
@@ -5,7 +5,7 @@ export default function SessionItem({ session, onDelete, onView }: { session: an
   return (
     <View style={styles.item}>
       <Text style={styles.type}>{session.type || 'Session'}</Text>
-      <Text style={styles.date}>{new Date(session.created).toLocaleString()}</Text>
+      <Text style={styles.date}>{new Date(session.date || session.created).toLocaleString()}</Text>
       <Text style={styles.info}>Anomalies: {session.anomalies?.length ?? 0}</Text>
       <View style={styles.actions}>
         <Pressable onPress={onView} style={styles.actionButton}><Text style={styles.actionText}>View</Text></Pressable>

--- a/screens/EVPRecorder.tsx
+++ b/screens/EVPRecorder.tsx
@@ -10,6 +10,7 @@ export default function EVPRecorder() {
   const [uri, setUri] = useState<string | null>(null);
   const [markers, setMarkers] = useState<number[]>([]);
   const [anomalies, setAnomalies] = useState<any[]>([]);
+  const [audioBuffer, setAudioBuffer] = useState<number[]>([]);
 
   const start = async () => {
     await Recorder.startRecording();
@@ -26,6 +27,7 @@ export default function EVPRecorder() {
     setMarkers(Recorder.getMarkers());
     // Simulate anomaly detection (replace with real buffer later)
     const fakeBuffer = new Float32Array(2048).map(() => Math.random() * 2 - 1);
+    setAudioBuffer(Array.from(fakeBuffer));
     setAnomalies(detectAnomalies(fakeBuffer));
   };
 
@@ -70,7 +72,7 @@ export default function EVPRecorder() {
           </View>
         )}
       </View>
-      <SpectrogramPreview />
+      <SpectrogramPreview audioBuffer={audioBuffer} />
       <View style={styles.buttons}>
         {!recording ? (
           <Button title="Start Recording" onPress={start} />

--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
 import SessionStore from '../services/sessions/SessionStore';
 import SessionItem from '../components/logbook/SessionItem';
 
@@ -12,6 +12,15 @@ export default function Logbook({ navigation }: any) {
     })();
   }, []);
 
+  const handleDelete = async (id: string) => {
+    await SessionStore.delete(id);
+    setSessions((s) => s.filter((sess) => sess.id !== id));
+  };
+
+  const handleView = (session: any) => {
+    navigation?.navigate?.('SessionDetail', { session });
+  };
+
   return (
     <View style={styles.flex}>
       <Text style={styles.title}>Logbook</Text>
@@ -19,9 +28,11 @@ export default function Logbook({ navigation }: any) {
         data={sessions}
         keyExtractor={item => item.id}
         renderItem={({ item }) => (
-          <TouchableOpacity onPress={() => navigation?.navigate?.('SessionDetail', { session: item })}>
-            <SessionItem session={item} />
-          </TouchableOpacity>
+          <SessionItem
+            session={item}
+            onView={() => handleView(item)}
+            onDelete={() => handleDelete(item.id)}
+          />
         )}
         contentContainerStyle={{ padding: 16 }}
         ListEmptyComponent={<Text style={styles.empty}>No sessions yet.</Text>}

--- a/screens/SpiritBoard.tsx
+++ b/screens/SpiritBoard.tsx
@@ -15,10 +15,9 @@ export default function SpiritBoard() {
 
   // Use entropy from sensors for pointer movement
   useEffect(() => {
-    const interval = setInterval(() => {
+    const interval = setInterval(async () => {
+      const e = await getEntropy();
       setPointer((p) => {
-        // Use entropy to bias movement
-        const e = getEntropy();
         let row = p.row + (e > 0.5 ? 1 : -1) * (e > 0.7 ? 1 : 0);
         let col = p.col + (e < 0.5 ? 1 : -1) * (e < 0.3 ? 1 : 0);
         row = Math.max(0, Math.min(LETTERS.length - 1, row));


### PR DESCRIPTION
## Summary
- wire up spectrogram preview with buffered data
- add view/delete handlers for logbook sessions
- await async entropy source for spirit board pointer

## Testing
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aefe9b1324832e9951067df90f58df