### PR TITLE
Add analytics and crash reporting infrastructure with opt-out controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# EchoVoid
+
+This project demonstrates basic analytics and error-reporting integrations. Users may opt in or out of these features at any time.
+
+## Analytics
+
+Analytics events are sent through `AnalyticsService` which can be configured with a provider such as Firebase Analytics. The service can be disabled in the settings screen or programmatically via `setEnabled(false)`.
+
+## Crash Reporting
+
+Unhandled exceptions are captured by `ErrorHandler` and forwarded to a crash-reporting provider. Crash reporting can also be disabled from the settings screen or programmatically.
+
+## User Controls
+
+The **Settings** screen exposes toggles for both analytics and crash reporting so users can decide whether to share diagnostic information.

--- a/src/analytics/analytics_service.ts
+++ b/src/analytics/analytics_service.ts
@@ -1,0 +1,35 @@
+export interface AnalyticsEvent {
+  name: string;
+  params?: Record<string, any>;
+}
+
+/**
+ * AnalyticsService wraps an analytics provider (e.g., Firebase Analytics).
+ * In production the provider would be initialised elsewhere and injected
+ * into this service. For this repository a basic interface is provided.
+ */
+export class AnalyticsService {
+  private enabled = true;
+
+  constructor(private provider?: { logEvent: (name: string, params?: Record<string, any>) => Promise<void> | void }) {}
+
+  /**
+   * Enable or disable analytics collection.
+   */
+  setEnabled(value: boolean) {
+    this.enabled = value;
+  }
+
+  /**
+   * Log an analytics event via the provider if enabled.
+   */
+  async logEvent(event: AnalyticsEvent): Promise<void> {
+    if (!this.enabled) return;
+    try {
+      await this.provider?.logEvent(event.name, event.params);
+    } catch (err) {
+      // Provider errors are swallowed so that analytics never break the app.
+      console.error('Analytics provider failed', err);
+    }
+  }
+}

--- a/src/errors/error_handler.ts
+++ b/src/errors/error_handler.ts
@@ -1,0 +1,35 @@
+/**
+ * ErrorHandler captures unhandled exceptions and forwards them to a crash
+ * reporting service. The crash service can be any provider implementing
+ * the simple `recordError` interface used here.
+ */
+export class ErrorHandler {
+  private enabled = true;
+
+  constructor(private crashService?: { recordError: (error: any) => Promise<void> | void }) {
+    // Bind the handler to the global error events where available.
+    if (typeof window !== 'undefined') {
+      window.addEventListener('error', (e) => this.capture(e.error));
+      window.addEventListener('unhandledrejection', (e) => this.capture(e.reason));
+    }
+  }
+
+  /**
+   * Enable or disable crash reporting.
+   */
+  setEnabled(value: boolean) {
+    this.enabled = value;
+  }
+
+  /**
+   * Capture an error and send it to the crash reporting service if enabled.
+   */
+  async capture(error: any): Promise<void> {
+    if (!this.enabled) return;
+    try {
+      await this.crashService?.recordError(error);
+    } catch (err) {
+      console.error('Crash service failed', err);
+    }
+  }
+}

--- a/src/ui/settings_screen.ts
+++ b/src/ui/settings_screen.ts
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { AnalyticsService } from '../analytics/analytics_service';
+import { ErrorHandler } from '../errors/error_handler';
+
+const analytics = new AnalyticsService();
+const errorHandler = new ErrorHandler();
+
+/**
+ * SettingsScreen exposes toggles allowing the user to opt in or out of
+ * analytics and crash reporting.
+ */
+export function SettingsScreen() {
+  const [analyticsEnabled, setAnalyticsEnabled] = useState(true);
+  const [crashEnabled, setCrashEnabled] = useState(true);
+
+  const toggleAnalytics = () => {
+    const next = !analyticsEnabled;
+    setAnalyticsEnabled(next);
+    analytics.setEnabled(next);
+  };
+
+  const toggleCrash = () => {
+    const next = !crashEnabled;
+    setCrashEnabled(next);
+    errorHandler.setEnabled(next);
+  };
+
+  return (
+    <div>
+      <h1>Settings</h1>
+      <label>
+        <input type="checkbox" checked={analyticsEnabled} onChange={toggleAnalytics} />
+        Enable analytics
+      </label>
+      <label>
+        <input type="checkbox" checked={crashEnabled} onChange={toggleCrash} />
+        Enable crash reporting
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add analytics service wrapper with provider support
- Add error handler sending unhandled exceptions to crash service
- Document analytics/crash reporting opt-out and expose toggles in settings screen

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb6f17590832eb274c6d59558fb75