### PR TITLE
feat: add theme support with user toggle

### DIFF
--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { lightPalette, darkPalette, Palette } from './themes';
+
+export type ThemeName = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Palette;
+  themeName: ThemeName;
+  setThemeName: (name: ThemeName) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: lightPalette,
+  themeName: 'light',
+  setThemeName: () => {},
+});
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [themeName, setThemeName] = useState<ThemeName>(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('theme') : null;
+    return stored === 'dark' ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', themeName);
+    }
+  }, [themeName]);
+
+  const theme = themeName === 'dark' ? darkPalette : lightPalette;
+
+  return (
+    <ThemeContext.Provider value={{ theme, themeName, setThemeName }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -1,0 +1,20 @@
+export type Palette = {
+  background: string;
+  text: string;
+  primary: string;
+  accent: string;
+};
+
+export const lightPalette: Palette = {
+  background: '#ffffff',
+  text: '#000000',
+  primary: '#1976d2',
+  accent: '#f50057',
+};
+
+export const darkPalette: Palette = {
+  background: '#121212',
+  text: '#ffffff',
+  primary: '#90caf9',
+  accent: '#ff4081',
+};

--- a/src/ui/ThemedButton.tsx
+++ b/src/ui/ThemedButton.tsx
@@ -1,0 +1,21 @@
+import React, { ButtonHTMLAttributes } from 'react';
+import { useTheme } from '../theme/ThemeProvider';
+
+export const ThemedButton = (
+  props: ButtonHTMLAttributes<HTMLButtonElement>
+) => {
+  const { theme } = useTheme();
+  return (
+    <button
+      {...props}
+      style={{
+        backgroundColor: theme.primary,
+        color: theme.text,
+        border: `1px solid ${theme.accent}`,
+        padding: '8px 16px',
+      }}
+    />
+  );
+};
+
+export default ThemedButton;

--- a/src/ui/settings_screen.tsx
+++ b/src/ui/settings_screen.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useTheme } from '../theme/ThemeProvider';
+
+export const SettingsScreen = () => {
+  const { theme, themeName, setThemeName } = useTheme();
+
+  const toggle = () => setThemeName(themeName === 'dark' ? 'light' : 'dark');
+
+  return (
+    <div
+      style={{
+        background: theme.background,
+        color: theme.text,
+        minHeight: '100vh',
+        padding: 16,
+      }}
+    >
+      <h1>Settings</h1>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span>Dark Mode</span>
+        <input type="checkbox" checked={themeName === 'dark'} onChange={toggle} />
+      </label>
+    </div>
+  );
+};
+
+export default SettingsScreen;


### PR DESCRIPTION
## Summary
- define light and dark palettes
- add theme provider with persistence
- create settings screen toggle and themed button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb6a9b1c4832e996b92df5f5ab2c6