### PR TITLE
feat: add high-contrast theme and scalable fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ npm test
 
 This scaffold includes stubs for cloud sync, shared sessions, anomaly detection, AR mode, voice cloning, advanced sweep presets, accessibility themes, privacy controls, and feedback channels.
 
+## Accessibility
+
+The app supports scalable typography and a high-contrast color palette.
+- Enable **High Contrast** from the Settings screen to switch to a simplified, high-visibility theme.
+- Text automatically adjusts based on system font settings and screen reader preferences.
+

--- a/components/controls/Chip.tsx
+++ b/components/controls/Chip.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 export default function Chip({ options, value, onChange }: {
   options: string[];
   value: string;
@@ -24,5 +25,5 @@ export default function Chip({ options, value, onChange }: {
 const styles = StyleSheet.create({
   row: { flexDirection: 'row', gap: 8, marginVertical: 8 },
   chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 2 },
-  text: { fontWeight: '600', fontSize: 14 },
+  text: { fontWeight: '600', fontSize: scaleFont(14) },
 });

--- a/components/controls/Knob.tsx
+++ b/components/controls/Knob.tsx
@@ -3,6 +3,7 @@ import { View, Text, PanResponder, StyleSheet } from 'react-native';
 import Animated, { useSharedValue, useAnimatedProps, withSpring } from 'react-native-reanimated';
 import Svg, { Circle, G, Path as SvgPath } from 'react-native-svg';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 const TICK_COUNT = 18;
 
 function polarToCartesian(cx: number, cy: number, r: number, angle: number) {
@@ -95,5 +96,5 @@ export default function Knob({ value, onChange, min = 0, max = 1, step = 0.01, s
 }
 const styles = StyleSheet.create({
   label: { fontWeight: '600', marginTop: 2 },
-  value: { fontWeight: '700', fontSize: 16 },
+  value: { fontWeight: '700', fontSize: scaleFont(16) },
 });

--- a/components/controls/Slider.tsx
+++ b/components/controls/Slider.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 export default function EVoidSlider({ value, onChange, min = 0, max = 1, step = 0.01, label, format }: {
   value: number;
   onChange: (v: number) => void;
@@ -34,5 +35,5 @@ const styles = StyleSheet.create({
   wrap: { width: '100%', marginVertical: 8 },
   label: { marginBottom: 4, fontWeight: '600' },
   slider: { width: '100%' },
-  value: { fontWeight: '700', fontSize: 15, marginTop: 2 },
+  value: { fontWeight: '700', fontSize: scaleFont(15), marginTop: 2 },
 });

--- a/components/controls/Timer.tsx
+++ b/components/controls/Timer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withRepeat, withTiming } from 'react-native-reanimated';
+import { scaleFont } from 'src/utils/scale';
 
 export default function Timer({ ms }: { ms: number }) {
   const mm = Math.floor(ms / 60000).toString().padStart(2, '0');
@@ -15,5 +16,5 @@ export default function Timer({ ms }: { ms: number }) {
   return <Animated.Text style={[styles.timer, style]}>{mm}:{ss}</Animated.Text>;
 }
 const styles = StyleSheet.create({
-  timer: { fontSize: 22, fontWeight: '700', letterSpacing: 1, color: '#fff', textAlign: 'center' },
+  timer: { fontSize: scaleFont(22), fontWeight: '700', letterSpacing: 1, color: '#fff', textAlign: 'center' },
 });

--- a/components/logbook/SessionDetail.tsx
+++ b/components/logbook/SessionDetail.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { Audio } from 'expo-av';
 import EVoidButton from '../ui/EVoidButton';
 import { shareSessionZip } from '../../services/export/zipSession';
+import { scaleFont } from 'src/utils/scale';
 
 export default function SessionDetail({ route }: any) {
   const session = route?.params?.session;
@@ -62,7 +63,7 @@ export default function SessionDetail({ route }: any) {
 }
 const styles = StyleSheet.create({
   detail: { flex: 1, padding: 20, backgroundColor: '#111' },
-  title: { fontSize: 24, fontWeight: '800', color: '#fff', marginBottom: 16 },
+  title: { fontSize: scaleFont(24), fontWeight: '800', color: '#fff', marginBottom: 16 },
   label: { color: '#aaa', fontWeight: '600', marginTop: 12 },
-  value: { color: '#fff', fontSize: 15, marginTop: 2 },
+  value: { color: '#fff', fontSize: scaleFont(15), marginTop: 2 },
 });

--- a/components/logbook/SessionItem.tsx
+++ b/components/logbook/SessionItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { scaleFont } from 'src/utils/scale';
 // TODO: Show session summary, type, date, and quick actions
 export default function SessionItem({ session, onDelete, onView }: { session: any; onDelete: () => void; onView: () => void }) {
   return (
@@ -16,10 +17,10 @@ export default function SessionItem({ session, onDelete, onView }: { session: an
 }
 const styles = StyleSheet.create({
   item: { padding: 16, borderRadius: 12, backgroundColor: '#222', marginVertical: 6 },
-  type: { color: '#fff', fontWeight: '700', fontSize: 16 },
-  date: { color: '#aaa', fontSize: 13, marginTop: 2 },
-  info: { color: '#8ff', fontSize: 13, marginTop: 4 },
+  type: { color: '#fff', fontWeight: '700', fontSize: scaleFont(16) },
+  date: { color: '#aaa', fontSize: scaleFont(13), marginTop: 2 },
+  info: { color: '#8ff', fontSize: scaleFont(13), marginTop: 4 },
   actions: { flexDirection: 'row', marginTop: 8 },
   actionButton: { marginRight: 12, padding: 8, backgroundColor: '#444', borderRadius: 8 },
-  actionText: { color: '#fff', fontSize: 13 },
+  actionText: { color: '#fff', fontSize: scaleFont(13) },
 });

--- a/components/ui/EVoidButton.tsx
+++ b/components/ui/EVoidButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 
 type Props = {
   label: string;
@@ -17,6 +18,7 @@ export default function EVoidButton({ label, onPress, variant = 'solid', style, 
     <Pressable
       testID={testID}
       accessibilityRole="button"
+      accessibilityLabel={label}
       hitSlop={12}
       onPress={disabled ? undefined : onPress}
       style={({ pressed }) => [
@@ -37,5 +39,5 @@ export default function EVoidButton({ label, onPress, variant = 'solid', style, 
 }
 const styles = StyleSheet.create({
   btn: { paddingVertical: 14, paddingHorizontal: 20, borderRadius: 14, alignItems: 'center', marginVertical: 4 },
-  text: { fontSize: 16, fontWeight: '700', letterSpacing: 0.4 },
+  text: { fontSize: scaleFont(16), fontWeight: '700', letterSpacing: 0.4 },
 });

--- a/components/ui/EVoidChip.tsx
+++ b/components/ui/EVoidChip.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 
 type Props = { label: string; selected?: boolean; style?: ViewStyle | ViewStyle[] };
 export default function EVoidChip({ label, selected, style }: Props) {
   const { theme } = useTheme();
   return (
-    <View style={[styles.chip, { backgroundColor: selected ? theme.colors.accent : theme.colors.surface }, style]}>
+    <View
+      accessible
+      accessibilityRole="text"
+      accessibilityLabel={label}
+      style={[styles.chip, { backgroundColor: selected ? theme.colors.accent : theme.colors.surface }, style]}
+    >
       <Text style={[styles.text, { color: selected ? theme.colors.bg : theme.colors.text }]}>{label}</Text>
     </View>
   );
 }
 const styles = StyleSheet.create({
   chip: { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 16, margin: 4 },
-  text: { fontWeight: '600', fontSize: 14 },
+  text: { fontWeight: '600', fontSize: scaleFont(14) },
 });

--- a/components/ui/EVoidDialog.tsx
+++ b/components/ui/EVoidDialog.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 
 type Props = { visible: boolean; title: string; children: React.ReactNode; onClose: () => void };
 export default function EVoidDialog({ visible, title, children, onClose }: Props) {
@@ -8,7 +9,12 @@ export default function EVoidDialog({ visible, title, children, onClose }: Props
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <View style={styles.overlay}>
-        <View style={[styles.dialog, { backgroundColor: theme.colors.surface }]}> 
+        <View
+          style={[styles.dialog, { backgroundColor: theme.colors.surface }]}
+          accessible
+          accessibilityRole="dialog"
+          accessibilityLabel={title}
+        >
           <Text style={[styles.title, { color: theme.colors.text }]}>{title}</Text>
           {children}
         </View>
@@ -19,5 +25,5 @@ export default function EVoidDialog({ visible, title, children, onClose }: Props
 const styles = StyleSheet.create({
   overlay: { flex: 1, backgroundColor: '#0009', justifyContent: 'center', alignItems: 'center' },
   dialog: { borderRadius: 18, padding: 24, minWidth: 260 },
-  title: { fontWeight: '700', fontSize: 18, marginBottom: 12 },
+  title: { fontWeight: '700', fontSize: scaleFont(18), marginBottom: 12 },
 });

--- a/components/ui/EVoidListItem.tsx
+++ b/components/ui/EVoidListItem.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 
 type Props = { title: string; subtitle?: string; right?: React.ReactNode; style?: ViewStyle | ViewStyle[] };
 export default function EVoidListItem({ title, subtitle, right, style }: Props) {
   const { theme } = useTheme();
+  const accLabel = subtitle ? `${title}, ${subtitle}` : title;
   return (
-    <View style={[styles.item, { backgroundColor: theme.colors.surface }, style]}>
+    <View
+      accessible
+      accessibilityRole="summary"
+      accessibilityLabel={accLabel}
+      style={[styles.item, { backgroundColor: theme.colors.surface }, style]}
+    >
       <View style={{ flex: 1 }}>
         <Text style={[styles.title, { color: theme.colors.text }]}>{title}</Text>
         {subtitle && <Text style={[styles.subtitle, { color: theme.colors.accent }]}>{subtitle}</Text>}
@@ -17,6 +24,6 @@ export default function EVoidListItem({ title, subtitle, right, style }: Props) 
 }
 const styles = StyleSheet.create({
   item: { flexDirection: 'row', alignItems: 'center', padding: 16, borderRadius: 12, marginVertical: 4 },
-  title: { fontWeight: '700', fontSize: 16 },
-  subtitle: { fontSize: 13, marginTop: 2 },
+  title: { fontWeight: '700', fontSize: scaleFont(16) },
+  subtitle: { fontSize: scaleFont(13), marginTop: 2 },
 });

--- a/components/ui/EVoidSlider.tsx
+++ b/components/ui/EVoidSlider.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 
 type Props = { value: number; onValueChange: (v: number) => void; min?: number; max?: number; step?: number; label?: string };
 export default function EVoidSlider({ value, onValueChange, min = 0, max = 1, step = 0.01, label }: Props) {
@@ -19,12 +20,14 @@ export default function EVoidSlider({ value, onValueChange, min = 0, max = 1, st
         maximumTrackTintColor={theme.colors.surface}
         thumbTintColor={theme.colors.primary}
         style={styles.slider}
+        accessibilityRole="adjustable"
+        accessibilityLabel={label || 'slider'}
       />
     </View>
   );
 }
 const styles = StyleSheet.create({
   wrap: { width: '100%', marginVertical: 8 },
-  label: { marginBottom: 4, fontWeight: '600' },
+  label: { marginBottom: 4, fontWeight: '600', fontSize: scaleFont(14) },
   slider: { width: '100%' },
 });

--- a/components/ui/EVoidToast.tsx
+++ b/components/ui/EVoidToast.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 
 type Props = { message: string; type?: 'info' | 'danger' | 'success' };
 export default function EVoidToast({ message, type = 'info' }: Props) {
   const { theme } = useTheme();
   const color = type === 'danger' ? theme.colors.danger : type === 'success' ? theme.colors.accent : theme.colors.primary;
   return (
-    <View style={[styles.toast, { borderColor: color }]}> 
+    <View
+      style={[styles.toast, { borderColor: color }]}
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+    >
       <Text style={[styles.text, { color }]}>{message}</Text>
     </View>
   );
 }
 const styles = StyleSheet.create({
   toast: { position: 'absolute', bottom: 32, left: 24, right: 24, backgroundColor: '#222E', borderRadius: 12, borderWidth: 2, padding: 16, alignItems: 'center' },
-  text: { fontWeight: '700', fontSize: 15 },
+  text: { fontWeight: '700', fontSize: scaleFont(15) },
 });

--- a/components/ui/EVoidToggle.tsx
+++ b/components/ui/EVoidToggle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Switch, View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
+import { scaleFont } from 'src/utils/scale';
 
 type Props = { value: boolean; onValueChange: (v: boolean) => void; label?: string };
 export default function EVoidToggle({ value, onValueChange, label }: Props) {
@@ -13,11 +14,13 @@ export default function EVoidToggle({ value, onValueChange, label }: Props) {
         onValueChange={onValueChange}
         trackColor={{ true: theme.colors.accent, false: theme.colors.surface }}
         thumbColor={value ? theme.colors.primary : theme.colors.surface}
+        accessibilityRole="switch"
+        accessibilityLabel={label || 'toggle'}
       />
     </View>
   );
 }
 const styles = StyleSheet.create({
   row: { flexDirection: 'row', alignItems: 'center', marginVertical: 8 },
-  label: { marginRight: 12, fontWeight: '600' },
+  label: { marginRight: 12, fontWeight: '600', fontSize: scaleFont(14) },
 });

--- a/screens/EVPRecorder.tsx
+++ b/screens/EVPRecorder.tsx
@@ -4,6 +4,7 @@ import * as Recorder from '../services/audio/Recorder';
 import SessionStore from '../services/sessions/SessionStore';
 import SpectrogramPreview from '../components/evp/SpectrogramPreview';
 import { detectAnomalies } from '../src/core/anomaly/detector';
+import { scaleFont } from 'src/utils/scale';
 
 export default function EVPRecorder() {
   const [recording, setRecording] = useState(false);
@@ -87,7 +88,7 @@ export default function EVPRecorder() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  title: { fontSize: 28, fontWeight: 'bold', marginBottom: 16 },
+  title: { fontSize: scaleFont(28), fontWeight: 'bold', marginBottom: 16 },
   status: { marginBottom: 24 },
   buttons: { gap: 12 },
 });

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -1,9 +1,11 @@
+import React from 'react';
 
 
 import { View, Text, StyleSheet, Image } from 'react-native';
 import { useTheme } from '../theme';
 import ParticleField from '../components/fx/ParticleField';
 import EVoidButton from '../components/ui/EVoidButton';
+import { scaleFont } from 'src/utils/scale';
 
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../src/navigation/AppNavigator';
@@ -30,7 +32,7 @@ export default function Home() {
 const styles = StyleSheet.create({
   flex: { flex: 1 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 },
-  title: { fontSize: 40, fontWeight: '900', letterSpacing: 1, textTransform: 'uppercase' },
-  subtitle: { fontSize: 16, marginBottom: 24, fontWeight: '600' },
+  title: { fontSize: scaleFont(40), fontWeight: '900', letterSpacing: 1, textTransform: 'uppercase' },
+  subtitle: { fontSize: scaleFont(16), marginBottom: 24, fontWeight: '600' },
   btn: { width: 220, marginVertical: 6 },
 });

--- a/screens/LiveITC.tsx
+++ b/screens/LiveITC.tsx
@@ -15,6 +15,7 @@ import AudioReactiveBars from '../components/fx/AudioReactiveBars';
 import NoiseOverlay from '../components/fx/NoiseOverlay';
 import Timer from '../components/controls/Timer';
 import EVoidButton from '../components/ui/EVoidButton';
+import { scaleFont } from 'src/utils/scale';
 
 
 function LiveITC() {
@@ -116,14 +117,14 @@ function LiveITC() {
           <EVoidButton label={playing ? "Stop" : "Play"} onPress={playing ? () => setPlaying(false) : handlePlay} />
         </View>
         {recordingUri && (
-          <Text style={{ color: theme.colors.accent, fontSize: 14, marginTop: 8 }}>
+          <Text style={{ color: theme.colors.accent, fontSize: scaleFont(14), marginTop: 8 }}>
             Recording saved: {recordingUri}
           </Text>
         )}
         <View style={{ marginTop: 12 }}>
-          <Text style={{ color: theme.colors.text, fontSize: 12 }}>Magnetometer: {mag.map(v => v.toFixed(2)).join(', ')}</Text>
-          <Text style={{ color: theme.colors.text, fontSize: 12 }}>Accelerometer: {acc.map(v => v.toFixed(2)).join(', ')}</Text>
-          {word && <Text style={{ color: theme.colors.accent, fontSize: 18, marginTop: 8 }}>ITC Word: {word}</Text>}
+          <Text style={{ color: theme.colors.text, fontSize: scaleFont(12) }}>Magnetometer: {mag.map(v => v.toFixed(2)).join(', ')}</Text>
+          <Text style={{ color: theme.colors.text, fontSize: scaleFont(12) }}>Accelerometer: {acc.map(v => v.toFixed(2)).join(', ')}</Text>
+          {word && <Text style={{ color: theme.colors.accent, fontSize: scaleFont(18), marginTop: 8 }}>ITC Word: {word}</Text>}
         </View>
       </View>
       <AudioReactiveBars />
@@ -144,7 +145,7 @@ function LiveITC() {
 const styles = StyleSheet.create({
   flex: { flex: 1 },
   header: { alignItems: 'center', marginTop: 16, marginBottom: 8 },
-  title: { fontSize: 28, fontWeight: '800', letterSpacing: 1 },
+  title: { fontSize: scaleFont(28), fontWeight: '800', letterSpacing: 1 },
   row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 16, marginVertical: 12 },
 });
 

--- a/screens/Logbook.tsx
+++ b/screens/Logbook.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
 import SessionStore from '../services/sessions/SessionStore';
 import SessionItem from '../components/logbook/SessionItem';
+import { scaleFont } from 'src/utils/scale';
 
 export default function Logbook({ navigation }: any) {
   const [sessions, setSessions] = useState<any[]>([]);
@@ -32,6 +33,6 @@ export default function Logbook({ navigation }: any) {
 
 const styles = StyleSheet.create({
   flex: { flex: 1, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', margin: 16 },
+  title: { fontSize: scaleFont(28), fontWeight: '800', color: '#fff', margin: 16 },
   empty: { color: '#888', textAlign: 'center', marginTop: 40 },
 });

--- a/screens/Onboarding/HowTo.tsx
+++ b/screens/Onboarding/HowTo.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { scaleFont } from 'src/utils/scale';
 
 export default function OnboardingHowTo({ navigation }: any) {
   return (
@@ -19,7 +20,7 @@ export default function OnboardingHowTo({ navigation }: any) {
 
 const styles = StyleSheet.create({
   flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  title: { fontSize: scaleFont(28), fontWeight: '800', color: '#fff', marginBottom: 24 },
+  body: { color: '#ccc', fontSize: scaleFont(16), textAlign: 'center', marginBottom: 32 },
   btn: { minWidth: 160 },
 });

--- a/screens/Onboarding/Intro.tsx
+++ b/screens/Onboarding/Intro.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
+import { scaleFont } from 'src/utils/scale';
 
 export default function OnboardingIntro({ navigation }: any) {
   return (
@@ -17,7 +18,7 @@ export default function OnboardingIntro({ navigation }: any) {
 
 const styles = StyleSheet.create({
   flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  title: { fontSize: scaleFont(28), fontWeight: '800', color: '#fff', marginBottom: 24 },
+  body: { color: '#ccc', fontSize: scaleFont(16), textAlign: 'center', marginBottom: 32 },
   btn: { minWidth: 160 },
 });

--- a/screens/Onboarding/Privacy.tsx
+++ b/screens/Onboarding/Privacy.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import EVoidButton from '../../components/ui/EVoidButton';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { scaleFont } from 'src/utils/scale';
 
 export default function OnboardingPrivacy({ navigation }: any) {
   return (
@@ -26,7 +27,7 @@ export default function OnboardingPrivacy({ navigation }: any) {
 
 const styles = StyleSheet.create({
   flex: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
-  body: { color: '#ccc', fontSize: 16, textAlign: 'center', marginBottom: 32 },
+  title: { fontSize: scaleFont(28), fontWeight: '800', color: '#fff', marginBottom: 24 },
+  body: { color: '#ccc', fontSize: scaleFont(16), textAlign: 'center', marginBottom: 32 },
   btn: { minWidth: 160 },
 });

--- a/screens/Settings.tsx
+++ b/screens/Settings.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme, themes, ThemeName } from '../theme';
 import Chip from '../components/controls/Chip';
+import { scaleFont } from 'src/utils/scale';
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
@@ -23,6 +24,6 @@ export default function Settings() {
 
 const styles = StyleSheet.create({
   flex: { flex: 1, padding: 24 },
-  title: { fontSize: 28, fontWeight: '800', marginBottom: 24 },
-  label: { fontSize: 16, fontWeight: '600', marginTop: 18 },
+  title: { fontSize: scaleFont(28), fontWeight: '800', marginBottom: 24 },
+  label: { fontSize: scaleFont(16), fontWeight: '600', marginTop: 18 },
 });

--- a/screens/SigilMaker.tsx
+++ b/screens/SigilMaker.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 import buildSigil from '../services/sigil/buildSigil';
+import { scaleFont } from 'src/utils/scale';
 
 export default function SigilMaker() {
   const [phrase, setPhrase] = useState('');
@@ -34,7 +35,7 @@ export default function SigilMaker() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
-  title: { fontSize: 24, marginBottom: 16 },
+  title: { fontSize: scaleFont(24), marginBottom: 16 },
   input: { borderWidth: 1, borderColor: '#ccc', padding: 8, width: '100%', marginBottom: 16 },
   button: { color: 'blue', marginBottom: 16 },
 });

--- a/screens/SpiritBoard.tsx
+++ b/screens/SpiritBoard.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import getEntropy from '../services/rng/Entropy';
+import { scaleFont } from 'src/utils/scale';
 
 const LETTERS = [
   ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
@@ -53,11 +54,11 @@ export default function SpiritBoard() {
 
 const styles = StyleSheet.create({
   flex: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#111' },
-  title: { fontSize: 28, fontWeight: '800', color: '#fff', marginBottom: 24 },
+  title: { fontSize: scaleFont(28), fontWeight: '800', color: '#fff', marginBottom: 24 },
   grid: { marginBottom: 32 },
   row: { flexDirection: 'row' },
   cell: { width: 44, height: 44, borderRadius: 22, backgroundColor: '#222', margin: 6, alignItems: 'center', justifyContent: 'center' },
   pointer: { backgroundColor: '#00E0FF', borderWidth: 2, borderColor: '#fff' },
-  letter: { color: '#fff', fontSize: 22, fontWeight: '700' },
-  tip: { color: '#aaa', fontSize: 13, marginTop: 12 },
+  letter: { color: '#fff', fontSize: scaleFont(22), fontWeight: '700' },
+  tip: { color: '#aaa', fontSize: scaleFont(13), marginTop: 12 },
 });

--- a/src/components/UIButton.tsx
+++ b/src/components/UIButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
+import { scaleFont } from 'src/utils/scale';
 
 type Props = {
   label: string;
@@ -41,7 +42,7 @@ const styles = StyleSheet.create({
   },
   text: {
     color: 'white',
-    fontSize: 16,
+    fontSize: scaleFont(16),
     fontWeight: '700',
     letterSpacing: 0.4,
   },

--- a/src/screens/ARModeScreen.tsx
+++ b/src/screens/ARModeScreen.tsx
@@ -6,6 +6,7 @@ import { GLView } from 'expo-gl';
 import { Renderer } from 'expo-three';
 import * as THREE from 'three';
 import { colors } from '../theme/colors';
+import { scaleFont } from 'src/utils/scale';
 
 const { width, height } = Dimensions.get('window');
 
@@ -84,6 +85,6 @@ export default function ARModeScreen({ navigation }: any) {
 
 const styles = StyleSheet.create({
   overlay: { position: 'absolute', top: 0, left: 0, right: 0, padding: 24, alignItems: 'center' },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700', marginTop: 32 },
+  h1: { color: colors.text, fontSize: scaleFont(28), fontWeight: '700', marginTop: 32 },
   p: { color: colors.subtext, marginTop: 8 },
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -6,6 +6,7 @@ import type { RootStackParamList } from '../navigation/AppNavigator';
 import UIButton from '../components/UIButton';
 import { colors } from '../theme/colors';
 import { hasNativeVoice, startListening } from '../voice/adapter';
+import { scaleFont } from 'src/utils/scale';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
@@ -59,10 +60,13 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   title: {
-    color: colors.text, fontSize: 44, fontWeight: '900', letterSpacing: 1, textTransform: 'uppercase',
+    color: colors.text, fontSize: scaleFont(44), fontWeight: '900', letterSpacing: 1, textTransform: 'uppercase',
   },
   subtitle: {
-    color: colors.subtext, marginTop: 6, marginBottom: 18,
+    color: colors.subtext,
+    fontSize: scaleFont(18),
+    marginTop: 6,
+    marginBottom: 18,
   },
   btn: {
     width: '90%',

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -8,6 +8,7 @@ import Toggle from '../components/Toggle';
 import { speakEsmera } from '../core/audio/tts';
 import { useTranscription } from '../core/audio/transcription';
 import { detectAnomalies, setSensitivity } from '../core/anomaly/detector';
+import { scaleFont } from 'src/utils/scale';
 
 export default function SessionScreen({navigation}:any){
   const { engine, session, start, stop, sync } = useSession();
@@ -26,22 +27,22 @@ export default function SessionScreen({navigation}:any){
 
   return (
   <ScrollView style={{flex:1, backgroundColor:colors.bg}} contentContainerStyle={{padding:16, gap:16}}>
-      <Text style={{color:colors.text, fontSize:18}}>Mode</Text>
+      <Text style={{color:colors.text, fontSize: scaleFont(18)}}>Mode</Text>
       <View style={{flexDirection:'row', flexWrap:'wrap'}}>
         {(['Standard','Mana','Reverse','DreamLink','Shadow','CallAndResponse'] as const).map(m =>
           <Toggle key={m} label={m} active={mode===m} onPress={()=>setMode(m)} />
         )}
       </View>
 
-  <Text style={{color:colors.text, fontSize:18}}>Sweep / Meter</Text>
+  <Text style={{color:colors.text, fontSize: scaleFont(18)}}>Sweep / Meter</Text>
       <Visualizer level={amp}/>
     <Meter level={amp} color={colors.neon}/>
 
-  <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Transcript</Text>
+  <Text style={{color:colors.text, fontSize: scaleFont(18), marginTop:8}}>Transcript</Text>
   <Text style={{color:colors.neon}}>{text || '…listening…'}</Text>
     <Text style={{color:colors.neon2, opacity:conf==null?0.5:1}}>confidence: {conf==null?'—':Math.round(conf*100)+'%'}</Text>
 
-  <Text style={{color:colors.text, fontSize:18, marginTop:8}}>Anomalies</Text>
+  <Text style={{color:colors.text, fontSize: scaleFont(18), marginTop:8}}>Anomalies</Text>
   {hits.map((h,i)=>(<Text key={i} style={{color:colors.neon2}}>{`hit @${Math.round(h.freq)}Hz (${Math.round(h.confidence*100)}%)`}</Text>))}
 
       <View style={{flexDirection:'row', gap:12, marginTop:8}}>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,23 +1,27 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { colors } from '../theme/colors';
+import { View, Text, StyleSheet, Switch } from 'react-native';
+import { useTheme, themes, ThemeName } from '../../theme';
+import Chip from '../../components/controls/Chip';
+import { scaleFont } from 'src/utils/scale';
 
-export default function SettingsScreen({ navigation }: { navigation: any }) {
-  // Log navigation prop
-  console.log('[SettingsScreen] navigation prop:', navigation);
-
+export default function SettingsScreen() {
+  const { theme, setTheme, highContrast, setHighContrast } = useTheme();
   return (
-    <LinearGradient colors={[colors.bg, '#0A0A1C', colors.card]} style={{ flex: 1 }}>
-      <View style={styles.container}>
-        <Text style={styles.h1}>Settings</Text>
-        <Text style={styles.p}>(Add prefs like voice, theme, logging here)</Text>
-      </View>
-    </LinearGradient>
+    <View style={[styles.flex, { backgroundColor: theme.colors.bg }]}> 
+      <Text style={[styles.title, { color: theme.colors.text }]}>Settings</Text>
+      <Text style={[styles.label, { color: theme.colors.text }]}>Theme</Text>
+      <Chip options={Object.keys(themes) as ThemeName[]} value={theme.name} onChange={v => setTheme(v as ThemeName)} />
+        <View style={styles.row}>
+          <Text style={[styles.label, { color: theme.colors.text }]}>High Contrast</Text>
+          <Switch value={highContrast} onValueChange={setHighContrast} accessibilityLabel="High Contrast" />
+        </View>
+    </View>
   );
 }
+
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
-  p: { color: colors.subtext, marginTop: 8 },
+  flex: { flex: 1, padding: 24 },
+  title: { fontSize: scaleFont(28), fontWeight: '800', marginBottom: 24 },
+  label: { fontSize: scaleFont(16), fontWeight: '600', marginTop: 18 },
+  row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 12 },
 });

--- a/src/screens/TransmissionScreen.tsx
+++ b/src/screens/TransmissionScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme/colors';
+import { scaleFont } from 'src/utils/scale';
 
 // Added type annotation for navigation prop
 const TransmissionScreen = ({ navigation }: { navigation: any }) => {
@@ -20,7 +21,7 @@ const TransmissionScreen = ({ navigation }: { navigation: any }) => {
 
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  h1: { color: colors.text, fontSize: 28, fontWeight: '700' },
+  h1: { color: colors.text, fontSize: scaleFont(28), fontWeight: '700' },
   p: { color: colors.subtext, marginTop: 8 },
 });
 

--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -3,6 +3,7 @@ import { View, Text, Pressable, StyleSheet, Dimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../../theme';
 import { themeColors } from '../theme/theme';
+import { scaleFont } from 'src/utils/scale';
 
 const { width, height } = Dimensions.get('window');
 
@@ -71,7 +72,7 @@ const styles = StyleSheet.create({
     padding: 32,
   },
   title: {
-    fontSize: 38,
+    fontSize: scaleFont(38),
     fontWeight: '900',
     letterSpacing: 2,
     textShadowColor: '#000a',
@@ -79,7 +80,7 @@ const styles = StyleSheet.create({
     textShadowRadius: 12,
   },
   subtitle: {
-    fontSize: 18,
+    fontSize: scaleFont(18),
     fontWeight: '500',
     marginTop: 10,
     marginBottom: 32,
@@ -100,7 +101,7 @@ const styles = StyleSheet.create({
     shadowRadius: 8,
   },
   buttonText: {
-    fontSize: 18,
+    fontSize: scaleFont(18),
     fontWeight: '700',
     letterSpacing: 1,
   },

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,5 +1,7 @@
+import { scaleFont } from 'src/utils/scale';
+
 export const TYPE = {
-  h1: { fontSize: 28, fontWeight: '800', letterSpacing: 0.5 },
-  h2: { fontSize: 20, fontWeight: '700' },
-  body: { fontSize: 16, fontWeight: '400' }
+  h1: { fontSize: scaleFont(28), fontWeight: '800', letterSpacing: 0.5 },
+  h2: { fontSize: scaleFont(20), fontWeight: '700' },
+  body: { fontSize: scaleFont(16), fontWeight: '400' }
 };

--- a/src/utils/scale.ts
+++ b/src/utils/scale.ts
@@ -1,0 +1,18 @@
+import { PixelRatio, AccessibilityInfo } from 'react-native';
+
+let screenReaderEnabled = false;
+
+AccessibilityInfo.isScreenReaderEnabled().then(enabled => {
+  screenReaderEnabled = enabled;
+});
+
+AccessibilityInfo.addEventListener &&
+  AccessibilityInfo.addEventListener('screenReaderChanged', (enabled) => {
+    screenReaderEnabled = enabled;
+  });
+
+export function scaleFont(size: number) {
+  const fontScale = PixelRatio.getFontScale();
+  const accessibilityScale = screenReaderEnabled ? 1.2 : 1;
+  return size * fontScale * accessibilityScale;
+}

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -19,6 +19,15 @@ export interface Theme {
   opacity: { [k: string]: number };
 }
 
+const highContrastPalette = {
+  bg: '#000000',
+  surface: '#000000',
+  primary: '#FFFFFF',
+  accent: '#FFFF00',
+  text: '#FFFFFF',
+  danger: '#FF0000',
+};
+
 export const themes: Record<ThemeName, Theme> = {
   Void: {
     name: 'Void',
@@ -55,21 +64,39 @@ export const themes: Record<ThemeName, Theme> = {
 interface ThemeContextType {
   theme: Theme;
   setTheme: (t: ThemeName) => void;
+  highContrast: boolean;
+  setHighContrast: (v: boolean) => void;
 }
 
-const ThemeContext = createContext<ThemeContextType>({ theme: themes.Void, setTheme: () => {} });
+const ThemeContext = createContext<ThemeContextType>({
+  theme: themes.Void,
+  setTheme: () => {},
+  highContrast: false,
+  setHighContrast: () => {},
+});
 
 export function ThemeProvider({ children }: PropsWithChildren<{}>) {
   const [themeName, setThemeName] = useState<ThemeName>('Void');
+  const [highContrast, setHighContrast] = useState(false);
   useEffect(() => {
-    AsyncStorage.getItem('theme').then((t: any) => { if (t && themes[t as ThemeName]) setThemeName(t as ThemeName); });
+    AsyncStorage.getItem('theme').then((t: any) => {
+      if (t && themes[t as ThemeName]) setThemeName(t as ThemeName);
+    });
+    AsyncStorage.getItem('highContrast').then(v => setHighContrast(v === '1'));
   }, []);
   const setTheme = (t: ThemeName) => {
     setThemeName(t);
     AsyncStorage.setItem('theme', t);
   };
+  const setHighContrastMode = (v: boolean) => {
+    setHighContrast(v);
+    AsyncStorage.setItem('highContrast', v ? '1' : '0');
+  };
+  const theme = highContrast
+    ? { ...themes[themeName], colors: highContrastPalette }
+    : themes[themeName];
   return (
-    <ThemeContext.Provider value={{ theme: themes[themeName], setTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme, highContrast, setHighContrast: setHighContrastMode }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add high-contrast palette with persistent toggle in settings
- scale fonts using PixelRatio/AccessibilityInfo and update UI controls with accessibility props
- document accessibility features in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aebf892b74832e85454d6e4afabfde