### PR TITLE
Fix TypeScript issues and await entropy in SpiritBoard

### DIFF
--- a/components/evp/SpectrogramPreview.tsx
+++ b/components/evp/SpectrogramPreview.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import { View } from 'react-native';
 import { Svg, Rect } from 'react-native-svg';
 
 interface SpectrogramPreviewProps {
-  audioBuffer: number[];
+  audioBuffer?: number[];
 }
 
-export default function SpectrogramPreview({ audioBuffer }: SpectrogramPreviewProps) {
+export default function SpectrogramPreview({ audioBuffer = [] }: SpectrogramPreviewProps) {
   const width = 300;
   const height = 80;
-  const barWidth = width / audioBuffer.length;
+  const barWidth = audioBuffer.length > 0 ? width / audioBuffer.length : width;
 
   return (
     <Svg height={height} width={width} style={{ backgroundColor: '#222' }}>

--- a/components/logbook/SessionItem.tsx
+++ b/components/logbook/SessionItem.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
+
+interface SessionItemProps {
+  session: any;
+  onDelete?: () => void;
+  onView?: () => void;
+}
+
 // TODO: Show session summary, type, date, and quick actions
-export default function SessionItem({ session, onDelete, onView }: { session: any; onDelete: () => void; onView: () => void }) {
+export default function SessionItem({ session, onDelete = () => {}, onView = () => {} }: SessionItemProps) {
+  const date = session.date ?? session.created ?? Date.now();
   return (
     <View style={styles.item}>
       <Text style={styles.type}>{session.type || 'Session'}</Text>
-      <Text style={styles.date}>{new Date(session.created).toLocaleString()}</Text>
+      <Text style={styles.date}>{new Date(date).toLocaleString()}</Text>
       <Text style={styles.info}>Anomalies: {session.anomalies?.length ?? 0}</Text>
       <View style={styles.actions}>
         <Pressable onPress={onView} style={styles.actionButton}><Text style={styles.actionText}>View</Text></Pressable>

--- a/screens/SpiritBoard.tsx
+++ b/screens/SpiritBoard.tsx
@@ -15,10 +15,10 @@ export default function SpiritBoard() {
 
   // Use entropy from sensors for pointer movement
   useEffect(() => {
-    const interval = setInterval(() => {
+    const interval = setInterval(async () => {
+      const e = await getEntropy();
       setPointer((p) => {
         // Use entropy to bias movement
-        const e = getEntropy();
         let row = p.row + (e > 0.5 ? 1 : -1) * (e > 0.7 ? 1 : 0);
         let col = p.col + (e < 0.5 ? 1 : -1) * (e < 0.3 ? 1 : 0);
         row = Math.max(0, Math.min(LETTERS.length - 1, row));


### PR DESCRIPTION
## Summary
- Make SpectrogramPreview audioBuffer prop optional and handle empty data
- Allow optional actions in SessionItem and display fallback date
- Await sensor entropy in SpiritBoard to avoid Promise comparisons

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7d8a89dc832e8a1f2664e02e04d5